### PR TITLE
Remove "using std::string" from port.h.

### DIFF
--- a/doc/examples/term_index.cc
+++ b/doc/examples/term_index.cc
@@ -46,7 +46,7 @@ int main(int argc, char **argv) {
 
   // We use a hash map as our inverted index.  The key is an index term, and
   // the value is the set of "document ids" where this index term is present.
-  std::unordered_map<string, std::vector<int>> index;
+  std::unordered_map<std::string, std::vector<int>> index;
 
   // Create an indexer suitable for an index that contains points only.
   // (You may also want to adjust min_level() or max_level() if you plan

--- a/src/s2/base/stringprintf.cc
+++ b/src/s2/base/stringprintf.cc
@@ -29,7 +29,7 @@ enum { IS__MSC_VER = 1 };
 enum { IS__MSC_VER = 0 };
 #endif
 
-void StringAppendV(string* dst, const char* format, va_list ap) {
+void StringAppendV(std::string* dst, const char* format, va_list ap) {
   // First try with a small fixed size buffer
   static const int kSpaceLength = 1024;
   char space[kSpaceLength];
@@ -81,16 +81,16 @@ void StringAppendV(string* dst, const char* format, va_list ap) {
 }
 
 
-string StringPrintf(const char* format, ...) {
+std::string StringPrintf(const char* format, ...) {
   va_list ap;
   va_start(ap, format);
-  string result;
+  std::string result;
   StringAppendV(&result, format, ap);
   va_end(ap);
   return result;
 }
 
-const string& SStringPrintf(string* dst, const char* format, ...) {
+const std::string& SStringPrintf(std::string* dst, const char* format, ...) {
   va_list ap;
   va_start(ap, format);
   dst->clear();
@@ -99,7 +99,7 @@ const string& SStringPrintf(string* dst, const char* format, ...) {
   return *dst;
 }
 
-void StringAppendF(string* dst, const char* format, ...) {
+void StringAppendF(std::string* dst, const char* format, ...) {
   va_list ap;
   va_start(ap, format);
   StringAppendV(dst, format, ap);

--- a/src/s2/base/stringprintf.h
+++ b/src/s2/base/stringprintf.h
@@ -29,17 +29,17 @@
 #include "s2/base/port.h"
 
 // Return a C++ string
-extern string StringPrintf(const char* format, ...)
+extern std::string StringPrintf(const char* format, ...)
     // Tell the compiler to do printf format string checking.
     ABSL_PRINTF_ATTRIBUTE(1, 2);
 
 // Store result into a supplied string and return it
-extern const string& SStringPrintf(string* dst, const char* format, ...)
+extern const std::string& SStringPrintf(std::string* dst, const char* format, ...)
     // Tell the compiler to do printf format string checking.
     ABSL_PRINTF_ATTRIBUTE(2, 3);
 
 // Append result to a supplied string
-extern void StringAppendF(string* dst, const char* format, ...)
+extern void StringAppendF(std::string* dst, const char* format, ...)
     // Tell the compiler to do printf format string checking.
     ABSL_PRINTF_ATTRIBUTE(2, 3);
 
@@ -48,6 +48,6 @@ extern void StringAppendF(string* dst, const char* format, ...)
 //
 // Implementation note: the va_list is never modified, this implementation
 // always operates on copies.
-extern void StringAppendV(string* dst, const char* format, va_list ap);
+extern void StringAppendV(std::string* dst, const char* format, va_list ap);
 
 #endif  // S2_BASE_STRINGPRINTF_H_

--- a/src/s2/base/strtoint.h
+++ b/src/s2/base/strtoint.h
@@ -95,11 +95,11 @@ inline int64 atoi64(const char *nptr) {
 }
 
 // Convenience versions of the above that take a string argument.
-inline int32 atoi32(const string &s) {
+inline int32 atoi32(const std::string &s) {
   return atoi32(s.c_str());
 }
 
-inline int64 atoi64(const string &s) {
+inline int64 atoi64(const std::string &s) {
   return atoi64(s.c_str());
 }
 

--- a/src/s2/encoded_string_vector.cc
+++ b/src/s2/encoded_string_vector.cc
@@ -37,7 +37,7 @@ void StringVectorEncoder::Encode(Encoder* encoder) {
   encoder->putn(data_.base(), data_.length());
 }
 
-void StringVectorEncoder::Encode(Span<const string> v, Encoder* encoder) {
+void StringVectorEncoder::Encode(Span<const std::string> v, Encoder* encoder) {
   StringVectorEncoder string_vector;
   for (const auto& str : v) string_vector.Add(str);
   string_vector.Encode(encoder);

--- a/src/s2/encoded_string_vector.h
+++ b/src/s2/encoded_string_vector.h
@@ -43,7 +43,7 @@ class StringVectorEncoder {
   StringVectorEncoder();
 
   // Adds a string to the encoded vector.
-  void Add(const string& str);
+  void Add(const std::string& str);
 
   // Adds a string to the encoded vector by means of the given Encoder.  The
   // string consists of all output added to the encoder before the next call
@@ -61,7 +61,7 @@ class StringVectorEncoder {
   //
   // REQUIRES: "encoder" uses the default constructor, so that its buffer
   //           can be enlarged as necessary by calling Ensure(int).
-  static void Encode(absl::Span<const string> v, Encoder* encoder);
+  static void Encode(absl::Span<const std::string> v, Encoder* encoder);
 
  private:
   // A vector consisting of the starting offset of each string in the
@@ -122,7 +122,7 @@ class EncodedStringVector {
 //////////////////   Implementation details follow   ////////////////////
 
 
-inline void StringVectorEncoder::Add(const string& str) {
+inline void StringVectorEncoder::Add(const std::string& str) {
   offsets_.push_back(data_.length());
   data_.Ensure(str.size());
   data_.putn(str.data(), str.size());

--- a/src/s2/encoded_string_vector_test.cc
+++ b/src/s2/encoded_string_vector_test.cc
@@ -26,7 +26,7 @@ using std::vector;
 
 namespace s2coding {
 
-void TestEncodedStringVector(const vector<string>& input,
+void TestEncodedStringVector(const vector<std::string>& input,
                              size_t expected_bytes) {
   Encoder encoder;
   StringVectorEncoder::Encode(input, &encoder);
@@ -62,7 +62,7 @@ TEST(EncodedStringVectorTest, TwoStrings) {
 }
 
 TEST(EncodedStringVectorTest, TwoBigStrings) {
-  TestEncodedStringVector({string(10000, 'x'), string(100000, 'y')},
+  TestEncodedStringVector({std::string(10000, 'x'), std::string(100000, 'y')},
                           110007);
 }
 

--- a/src/s2/id_set_lexicon.h
+++ b/src/s2/id_set_lexicon.h
@@ -49,7 +49,7 @@
 //   ValueLexicon<string> labels_;
 //   IdSetLexicon label_sets_;
 //
-//   int32 GetLabelSet(const vector<string>& label_strings) {
+//   int32 GetLabelSet(const vector<std::string>& label_strings) {
 //     vector<int32> label_ids;
 //     for (const auto& str : label_strings) {
 //       label_ids.push_back(labels_.Add(str));

--- a/src/s2/s2boolean_operation_test.cc
+++ b/src/s2/s2boolean_operation_test.cc
@@ -68,14 +68,14 @@ class IndexMatchingLayer : public S2Builder::Layer {
 
  private:
   using EdgeVector = vector<S2Shape::Edge>;
-  static string ToString(const EdgeVector& edges);
+  static std::string ToString(const EdgeVector& edges);
 
   const S2ShapeIndex& index_;
   int dimension_;
 };
 
-string IndexMatchingLayer::ToString(const EdgeVector& edges) {
-  string msg;
+std::string IndexMatchingLayer::ToString(const EdgeVector& edges) {
+  std::string msg;
   for (const auto& edge : edges) {
     vector<S2Point> vertices{edge.v0, edge.v1};
     msg += s2textformat::ToString(vertices);
@@ -127,8 +127,8 @@ void IndexMatchingLayer::Build(const Graph& g, S2Error* error) {
 
 void ExpectResult(S2BooleanOperation::OpType op_type,
                   const S2BooleanOperation::Options& options,
-                  const string& a_str, const string& b_str,
-                  const string& expected_str) {
+                  const std::string& a_str, const std::string& b_str,
+                  const std::string& expected_str) {
   auto a = s2textformat::MakeIndexOrDie(a_str);
   auto b = s2textformat::MakeIndexOrDie(b_str);
   auto expected = s2textformat::MakeIndexOrDie(expected_str);
@@ -538,7 +538,7 @@ TEST(S2BooleanOperation,
 }
 
 // The polygon used in the polyline/polygon vertex tests below.
-static string kVertexTestPolygonStr() {
+static std::string kVertexTestPolygonStr() {
   return "0:0, 0:1, 0:2, 0:3, 0:4, 0:5, 5:5, 5:4, 5:3, 5:2, 5:1, 5:0";
 }
 
@@ -572,7 +572,7 @@ TEST(S2BooleanOperation, PolylineVertexOpenPolygonVertex) {
             "| 6:1, 5:1 | 5:2, 6:2 | 4:3, 5:3 | 5:4, 4:4 #");
   auto b = "# # " + kVertexTestPolygonStr();
 
-  const string kDifferenceResult =
+  const std::string kDifferenceResult =
       "# 0:1, 0:1 | 0:2, 0:2 | -1:3, 0:3 | 0:4, -1:4"
       "| 6:1, 5:1 | 5:2, 6:2 | 5:3, 5:3 | 5:4, 5:4 #";
   ExpectResult(OpType::UNION, options, a, b,
@@ -588,7 +588,7 @@ TEST(S2BooleanOperation, PolylineVertexOpenPolygonVertex) {
 // closed polyline vertex.  This tests that when an open vertex and a closed
 // vertex coincide with each other, the result is considered closed.
 TEST(S2BooleanOperation, PolylineVertexOpenPolygonClosedPolylineVertex) {
-  const string kTestGeometrySuffix =
+  const std::string kTestGeometrySuffix =
       "-2:0, 0:1 | -2:1, 0:2 | -2:2, 0:3 | -2:3, 0:4 | "
       "7:0, 5:1 | 7:1, 5:2 | 7:2, 5:3 | 7:3, 5:4 # " + kVertexTestPolygonStr();
 
@@ -598,7 +598,7 @@ TEST(S2BooleanOperation, PolylineVertexOpenPolygonClosedPolylineVertex) {
             "| 6:1, 5:1 | 5:2, 6:2 | 4:3, 5:3 | 5:4, 4:4 #");
   auto b = ("# " + kTestGeometrySuffix);
 
-  const string kDifferencePrefix =
+  const std::string kDifferencePrefix =
       "# -1:3, 0:3 | 0:4, -1:4 | 6:1, 5:1 | 5:2, 6:2";
   ExpectResult(OpType::UNION, options, a, b,
                kDifferencePrefix +
@@ -626,7 +626,7 @@ TEST(S2BooleanOperation, PolylineVertexSemiOpenPolygonVertex) {
   auto a = ("# 1:1, 0:1 | 0:2, 1:2 | -1:3, 0:3 | 0:4, -1:4 "
             "| 6:1, 5:1 | 5:2, 6:2 | 4:3, 5:3 | 5:4, 4:4 #");
   auto b = "# # " + kVertexTestPolygonStr();
-  const string kDifferenceResult =
+  const std::string kDifferenceResult =
       "# -1:3, 0:3 | 0:4, -1:4 | 6:1, 5:1 | 5:2, 6:2 | 5:3, 5:3 | 5:4, 5:4 #";
   ExpectResult(OpType::UNION, options, a, b,
                kDifferenceResult + kVertexTestPolygonStr());
@@ -647,7 +647,7 @@ TEST(S2BooleanOperation, PolylineVertexClosedPolygonVertex) {
   auto a = ("# 1:1, 0:1 | 0:2, 1:2 | -1:3, 0:3 | 0:4, -1:4 "
             "| 6:1, 5:1 | 5:2, 6:2 | 4:3, 5:3 | 5:4, 4:4 #");
   auto b = "# # " + kVertexTestPolygonStr();
-  const string kDifferenceResult =
+  const std::string kDifferenceResult =
       "# -1:3, 0:3 | 0:4, -1:4 | 6:1, 5:1 | 5:2, 6:2 #";
   ExpectResult(OpType::UNION, options, a, b,
                kDifferenceResult + kVertexTestPolygonStr());
@@ -1179,10 +1179,10 @@ TEST(S2BooleanOperation, GetCrossedVertexIndexBug) {
 // Performs the given operation and compares the result to "expected_str".  All
 // arguments are in s2textformat::MakeLaxPolygon() format.
 void ExpectPolygon(S2BooleanOperation::OpType op_type,
-                   const string& a_str, const string& b_str,
-                   const string& expected_str) {
-  auto a = s2textformat::MakeIndexOrDie(string("# # ") + a_str);
-  auto b = s2textformat::MakeIndexOrDie(string("# # ") + b_str);
+                   const std::string& a_str, const std::string& b_str,
+                   const std::string& expected_str) {
+  auto a = s2textformat::MakeIndexOrDie(std::string("# # ") + a_str);
+  auto b = s2textformat::MakeIndexOrDie(std::string("# # ") + b_str);
   s2builderutil::LaxPolygonLayer::Options polygon_options;
   polygon_options.set_degenerate_boundaries(DegenerateBoundaries::DISCARD);
   S2LaxPolygonShape output;
@@ -1198,41 +1198,41 @@ void ExpectPolygon(S2BooleanOperation::OpType op_type,
 
 TEST(S2BooleanOperation, FullAndEmptyResults) {
   // The following constants are all in s2textformat::MakeLaxPolygon() format.
-  string kEmpty = "";
-  string kFull = "full";
+  std::string kEmpty = "";
+  std::string kFull = "full";
 
   // Two complementary shell/hole pairs, together with alternative shells that
   // are slightly smaller or larger than the original.
-  string kShell1 = "10:0, 10:10, 20:10";
-  string kHole1 = "10:0, 20:10, 10:10";
-  string kShell1Minus = "11:2, 11:9, 18:9";
-  string kShell1Plus = "9:-2, 9:11, 22:11";
-  string kShell2 = "10:20, 10:30, 20:30";
-  string kHole2 = "10:20, 20:30, 10:30";
+  std::string kShell1 = "10:0, 10:10, 20:10";
+  std::string kHole1 = "10:0, 20:10, 10:10";
+  std::string kShell1Minus = "11:2, 11:9, 18:9";
+  std::string kShell1Plus = "9:-2, 9:11, 22:11";
+  std::string kShell2 = "10:20, 10:30, 20:30";
+  std::string kHole2 = "10:20, 20:30, 10:30";
 
   // The northern and southern hemispheres.
-  string kNorthHemi = "0:0, 0:120, 0:-120";
-  string kSouthHemi = "0:0, 0:-120, 0:120";
+  std::string kNorthHemi = "0:0, 0:120, 0:-120";
+  std::string kSouthHemi = "0:0, 0:-120, 0:120";
   // These edges deviate from kSouthHemi by slightly more than 1 degree.
-  string kSouthHemiPlus = "0.5:0, 0.5:-120, 0.5:120";
+  std::string kSouthHemiPlus = "0.5:0, 0.5:-120, 0.5:120";
 
   // A shell and hole that cover complementary hemispheres, such that each
   // hemisphere intersects all six S2 cube faces.  There are also alternative
   // shells that are slightly smaller or larger than the original.
-  string k6FaceShell1 = "0:-45, 45:0, 45:90, 0:135, -45:180, -45:-90";
-  string k6FaceHole1 = "0:-45, -45:-90, -45:180, 0:135, 45:90, 45:0";
-  string k6FaceShell1Minus = "-1:-45, 44:0, 44:90, -1:135, -46:180, -46:-90";
-  string k6FaceShell1Plus = "1:-45, 46:0, 46:90, 1:135, -44:180, -44:-90";
+  std::string k6FaceShell1 = "0:-45, 45:0, 45:90, 0:135, -45:180, -45:-90";
+  std::string k6FaceHole1 = "0:-45, -45:-90, -45:180, 0:135, 45:90, 45:0";
+  std::string k6FaceShell1Minus = "-1:-45, 44:0, 44:90, -1:135, -46:180, -46:-90";
+  std::string k6FaceShell1Plus = "1:-45, 46:0, 46:90, 1:135, -44:180, -44:-90";
 
   // Two complementary shell/hole pairs that are small enough so that they will
   // disappear when the snap radius chosen above is used.
-  string kAlmostEmpty1 = "2:0, 2:10, 3:0";
-  string kAlmostFull1 = "2:0, 3:0, 2:10";
-  string kAlmostEmpty2 = "4:0, 4:10, 5:0";
-  string kAlmostFull2 = "4:0, 5:0, 4:10";
+  std::string kAlmostEmpty1 = "2:0, 2:10, 3:0";
+  std::string kAlmostFull1 = "2:0, 3:0, 2:10";
+  std::string kAlmostEmpty2 = "4:0, 4:10, 5:0";
+  std::string kAlmostFull2 = "4:0, 5:0, 4:10";
 
   // A polygon that intersects all 6 faces such but snaps to an empty polygon.
-  string k6FaceAlmostEmpty1 = k6FaceShell1Minus + "; " + k6FaceHole1;
+  std::string k6FaceAlmostEmpty1 = k6FaceShell1Minus + "; " + k6FaceHole1;
 
   // Test empty UNION results.
   //  - Exact result, no input edges.
@@ -1355,7 +1355,7 @@ TEST(S2BooleanOperation, FullAndEmptyResults) {
 
 // Tests whether the two S2ShapeIndexes are equal according to
 // S2BooleanOperation::Equals().
-bool TestEqual(const string& a_str, const string& b_str) {
+bool TestEqual(const std::string& a_str, const std::string& b_str) {
   auto a = s2textformat::MakeIndexOrDie(a_str);
   auto b = s2textformat::MakeIndexOrDie(b_str);
   return S2BooleanOperation::Equals(*a, *b);

--- a/src/s2/s2builder_test.cc
+++ b/src/s2/s2builder_test.cc
@@ -575,7 +575,7 @@ void TestPolylineLayers(
   }
   S2Error error;
   ASSERT_TRUE(builder.Build(&error));
-  vector<string> output_strs;
+  vector<std::string> output_strs;
   for (const auto& polyline : output) {
     output_strs.push_back(s2textformat::ToString(*polyline));
   }
@@ -597,7 +597,7 @@ void TestPolylineVector(
   }
   S2Error error;
   ASSERT_TRUE(builder.Build(&error));
-  vector<string> output_strs;
+  vector<std::string> output_strs;
   for (const auto& polyline : output) {
     output_strs.push_back(s2textformat::ToString(*polyline));
   }
@@ -814,7 +814,7 @@ TEST(S2Builder, SimplifyKeepsForcedVertices) {
 // A set of (edge string, vector<InputEdgeId>) pairs representing the
 // InputEdgeIds attached to the edges of a graph.  Edges are in
 // s2textformat::ToString() format, such as "1:3, 4:5".
-using EdgeInputEdgeIds = vector<pair<string, vector<int>>>;
+using EdgeInputEdgeIds = vector<pair<std::string, vector<int>>>;
 
 S2Error::Code INPUT_EDGE_ID_MISMATCH = S2Error::USER_DEFINED_START;
 
@@ -828,8 +828,8 @@ class InputEdgeIdCheckingLayer : public S2Builder::Layer {
   void Build(const Graph& g, S2Error* error) override;
 
  private:
-  string ToString(const pair<string, vector<int>>& p) {
-    string r = StrCat("  (", p.first, ")={");
+  std::string ToString(const pair<std::string, vector<int>>& p) {
+    std::string r = StrCat("  (", p.first, ")={");
     if (!p.second.empty()) {
       for (int id : p.second) {
         StrAppend(&r, id, ", ");
@@ -851,7 +851,7 @@ void InputEdgeIdCheckingLayer::Build(const Graph& g, S2Error* error) {
     vertices.clear();
     vertices.push_back(g.vertex(g.edge(e).first));
     vertices.push_back(g.vertex(g.edge(e).second));
-    string edge = s2textformat::ToString(
+    std::string edge = s2textformat::ToString(
         vector<S2Point>{g.vertex(g.edge(e).first),
                         g.vertex(g.edge(e).second)});
     auto ids = g.input_edge_ids(e);
@@ -859,7 +859,7 @@ void InputEdgeIdCheckingLayer::Build(const Graph& g, S2Error* error) {
         edge, vector<InputEdgeId>(ids.begin(), ids.end())));
   }
   // This comparison doesn't consider multiplicity, but that's fine.
-  string missing, extra;
+  std::string missing, extra;
   for (const auto& p : expected_) {
     if (std::count(actual.begin(), actual.end(), p) > 0) continue;
     missing += ToString(p);

--- a/src/s2/s2builderutil_closed_set_normalizer_test.cc
+++ b/src/s2/s2builderutil_closed_set_normalizer_test.cc
@@ -71,22 +71,22 @@ class NormalizeTest : public testing::Test {
                      DuplicateEdges::KEEP, SiblingPairs::KEEP));
   }
 
-  void Run(const string& input_str, const string& expected_str);
+  void Run(const std::string& input_str, const std::string& expected_str);
 
  protected:
   bool suppress_lower_dimensions_;
   vector<GraphOptions> graph_options_out_;
 
  private:
-  static string ToString(const Graph& g);
-  void AddLayers(const string& str, const vector<GraphOptions>& graph_options,
+  static std::string ToString(const Graph& g);
+  void AddLayers(const std::string& str, const vector<GraphOptions>& graph_options,
                  vector<Graph>* graphs_out, S2Builder* builder);
 
   vector<unique_ptr<GraphClone>> graph_clones_;
 };
 
-void NormalizeTest::Run(const string& input_str,
-                        const string& expected_str) {
+void NormalizeTest::Run(const std::string& input_str,
+                        const std::string& expected_str) {
   ClosedSetNormalizer::Options options;
   options.set_suppress_lower_dimensions(suppress_lower_dimensions_);
   ClosedSetNormalizer normalizer(options, graph_options_out_);
@@ -107,7 +107,7 @@ void NormalizeTest::Run(const string& input_str,
 }
 
 void NormalizeTest::AddLayers(
-    const string& str, const vector<GraphOptions>& graph_options,
+    const std::string& str, const vector<GraphOptions>& graph_options,
     vector<Graph>* graphs_out, S2Builder* builder) {
   auto index = s2textformat::MakeIndex(str);
   for (int dim = 0; dim < 3; ++dim) {
@@ -124,8 +124,8 @@ void NormalizeTest::AddLayers(
   }
 }
 
-string NormalizeTest::ToString(const Graph& g) {
-  string msg;
+std::string NormalizeTest::ToString(const Graph& g) {
+  std::string msg;
   for (const auto& edge : g.edges()) {
     vector<S2Point> vertices = { g.vertex(edge.first),
                                  g.vertex(edge.second) };

--- a/src/s2/s2builderutil_find_polygon_degeneracies_test.cc
+++ b/src/s2/s2builderutil_find_polygon_degeneracies_test.cc
@@ -46,9 +46,9 @@ using SiblingPairs = GraphOptions::SiblingPairs;
 namespace s2builderutil {
 
 struct TestDegeneracy {
-  string edge_str;
+  std::string edge_str;
   bool is_hole;
-  TestDegeneracy(string _edge_str, bool _is_hole)
+  TestDegeneracy(std::string _edge_str, bool _is_hole)
       : edge_str(_edge_str), is_hole(_is_hole) {
   }
 };
@@ -103,7 +103,7 @@ void DegeneracyCheckingLayer::Build(const Graph& g, S2Error* error) {
   EXPECT_EQ(IsFullyDegenerate(g), degeneracies.size() == g.num_edges());
 }
 
-void ExpectDegeneracies(const string& polygon_str,
+void ExpectDegeneracies(const std::string& polygon_str,
                         const vector<TestDegeneracy>& expected) {
   S2Builder builder{S2Builder::Options()};
   builder.StartLayer(make_unique<DegeneracyCheckingLayer>(expected));

--- a/src/s2/s2builderutil_lax_polygon_layer_test.cc
+++ b/src/s2/s2builderutil_lax_polygon_layer_test.cc
@@ -46,7 +46,7 @@ using DegenerateBoundaries = LaxPolygonLayer::Options::DegenerateBoundaries;
 
 namespace {
 
-string ToString(DegenerateBoundaries degenerate_boundaries) {
+std::string ToString(DegenerateBoundaries degenerate_boundaries) {
   switch (degenerate_boundaries) {
     case DegenerateBoundaries::DISCARD: return "DISCARD";
     case DegenerateBoundaries::DISCARD_HOLES: return "DISCARD_HOLES";
@@ -80,7 +80,7 @@ void TestLaxPolygon(string_view input_str, string_view expected_str,
   builder.AddIsFullPolygonPredicate(S2Builder::IsFullPolygon(has_full_loop));
   S2Error error;
   ASSERT_TRUE(builder.Build(&error));
-  string actual_str = s2textformat::ToString(output, "; ");
+  std::string actual_str = s2textformat::ToString(output, "; ");
   EXPECT_EQ(expected_str, actual_str);
 }
 
@@ -176,8 +176,8 @@ TEST(LaxPolygonLayer, AllDegenerateHoles) {
 }
 
 TEST(LaxPolygonLayer, SomeDegenerateShells) {
-  const string kNormal = "0:0, 0:9, 9:0; 1:1, 7:1, 1:7";
-  const string kInput = kNormal + "; 3:2; 2:2, 2:3";
+  const std::string kNormal = "0:0, 0:9, 9:0; 1:1, 7:1, 1:7";
+  const std::string kInput = kNormal + "; 3:2; 2:2, 2:3";
   TestLaxPolygonUnchanged(kInput, DegenerateBoundaries::KEEP);
   TestLaxPolygonUnchanged(kInput, DegenerateBoundaries::DISCARD_HOLES);
   TestLaxPolygon(kInput, kNormal, DegenerateBoundaries::DISCARD);
@@ -197,19 +197,19 @@ TEST(LaxPolygonLayer, SomeDegenerateHoles) {
 
 TEST(LaxPolygonLayer, NormalAndDegenerateShellsAndHoles) {
   // We start with two normal shells and one normal hole.
-  const string kNormal = "0:0, 0:9, 9:9, 9:0; "
+  const std::string kNormal = "0:0, 0:9, 9:9, 9:0; "
                          "0:10, 0:19, 9:19, 9:10; 1:11, 8:11, 8:18, 1:18";
   // These are the same loops augmented with degenerate interior filaments
   // (holes).  Note that one filament connects the second shell and hole
   // above, transforming them into a single loop.
-  const string kNormalWithDegenHoles =
+  const std::string kNormalWithDegenHoles =
       "0:0, 0:9, 1:8, 1:7, 1:8, 0:9, 9:9, 9:0; "
       "0:10, 0:19, 9:19, 9:10, 0:10, 1:11, 8:11, 8:18, 1:18, 1:11";
   // Then we add other degenerate shells and holes, including a sibling pair
   // that connects the two shells above.
-  const string kDegenShells = "0:9, 0:10; 2:12; 3:13, 3:14; 20:20; 10:0, 10:1";
-  const string kDegenHoles = "2:5; 3:6, 3:7; 8:8";
-  const string kInput = kNormalWithDegenHoles + "; " +
+  const std::string kDegenShells = "0:9, 0:10; 2:12; 3:13, 3:14; 20:20; 10:0, 10:1";
+  const std::string kDegenHoles = "2:5; 3:6, 3:7; 8:8";
+  const std::string kInput = kNormalWithDegenHoles + "; " +
                         kDegenShells + "; " + kDegenHoles;
   TestLaxPolygon(kInput, kNormal, DegenerateBoundaries::DISCARD);
   TestLaxPolygon(kInput, kNormal + "; " + kDegenShells,
@@ -342,7 +342,7 @@ TEST(IndexedLaxPolygonLayer, AddsShape) {
   S2Builder builder{S2Builder::Options()};
   MutableS2ShapeIndex index;
   builder.StartLayer(make_unique<IndexedLaxPolygonLayer>(&index));
-  const string& polygon_str = "0:0, 0:10, 10:0";
+  const std::string& polygon_str = "0:0, 0:10, 10:0";
   builder.AddPolygon(*s2textformat::MakePolygon(polygon_str));
   S2Error error;
   ASSERT_TRUE(builder.Build(&error));

--- a/src/s2/s2builderutil_s2point_vector_layer_test.cc
+++ b/src/s2/s2builderutil_s2point_vector_layer_test.cc
@@ -39,7 +39,7 @@ namespace {
 void VerifyS2PointVectorLayerResults(
     const S2PointVectorLayer::LabelSetIds& label_set_ids,
     const IdSetLexicon& label_set_lexicon, const vector<S2Point>& output,
-    const string& str_expected_points,
+    const std::string& str_expected_points,
     const vector<vector<int32>>& expected_labels) {
   vector<S2Point> expected_points =
       s2textformat::ParsePoints(str_expected_points);
@@ -82,7 +82,7 @@ TEST(S2PointVectorLayer, MergeDuplicates) {
   ASSERT_TRUE(builder.Build(&error));
 
   vector<vector<int32>> expected_labels = {{1, 2}, {1}, {2}, {2}, {}};
-  string expected_points = "0:1, 0:2, 0:4, 0:5, 0:6";
+  std::string expected_points = "0:1, 0:2, 0:4, 0:5, 0:6";
 
   VerifyS2PointVectorLayerResults(label_set_ids, label_set_lexicon, output,
                                   expected_points, expected_labels);
@@ -112,7 +112,7 @@ TEST(S2PointVectorLayer, KeepDuplicates) {
   ASSERT_TRUE(builder.Build(&error));
 
   vector<vector<int32>> expected_labels = {{1}, {2}, {1}, {2}, {2}, {}, {}};
-  string expected_points = "0:1, 0:1, 0:2, 0:4, 0:5, 0:5, 0:6";
+  std::string expected_points = "0:1, 0:1, 0:2, 0:4, 0:5, 0:5, 0:6";
 
   VerifyS2PointVectorLayerResults(label_set_ids, label_set_lexicon, output,
                                   expected_points, expected_labels);
@@ -142,8 +142,8 @@ TEST(IndexedS2PointVectorLayer, AddsShapes) {
   S2Builder builder{S2Builder::Options()};
   MutableS2ShapeIndex index;
   builder.StartLayer(make_unique<IndexedS2PointVectorLayer>(&index));
-  string point0_str = "0:0";
-  string point1_str = "2:2";
+  std::string point0_str = "0:0";
+  std::string point1_str = "2:2";
   builder.AddPoint(s2textformat::MakePointOrDie(point0_str));
   builder.AddPoint(s2textformat::MakePointOrDie(point1_str));
   S2Error error;

--- a/src/s2/s2builderutil_s2polygon_layer_test.cc
+++ b/src/s2/s2builderutil_s2polygon_layer_test.cc
@@ -52,7 +52,7 @@ void TestS2Polygon(const vector<const char*>& input_strs,
       &output, S2PolygonLayer::Options(edge_type)));
   bool is_full = false;
   for (auto input_str : input_strs) {
-    if (string(input_str) == "full") is_full = true;
+    if (std::string(input_str) == "full") is_full = true;
     builder.AddPolygon(*s2textformat::MakeVerbatimPolygonOrDie(input_str));
   }
   builder.AddIsFullPolygonPredicate(S2Builder::IsFullPolygon(is_full));
@@ -290,7 +290,7 @@ TEST(IndexedS2PolygonLayer, AddsShape) {
   S2Builder builder{S2Builder::Options()};
   MutableS2ShapeIndex index;
   builder.StartLayer(make_unique<IndexedS2PolygonLayer>(&index));
-  const string& polygon_str = "0:0, 0:10, 10:0";
+  const std::string& polygon_str = "0:0, 0:10, 10:0";
   builder.AddPolygon(*s2textformat::MakePolygon(polygon_str));
   S2Error error;
   ASSERT_TRUE(builder.Build(&error));

--- a/src/s2/s2builderutil_s2polyline_layer_test.cc
+++ b/src/s2/s2builderutil_s2polyline_layer_test.cc
@@ -196,7 +196,7 @@ TEST(IndexedS2PolylineLayer, AddsShape) {
   S2Builder builder{S2Builder::Options()};
   MutableS2ShapeIndex index;
   builder.StartLayer(make_unique<IndexedS2PolylineLayer>(&index));
-  const string& polyline_str = "0:0, 0:10";
+  const std::string& polyline_str = "0:0, 0:10";
   builder.AddPolyline(*MakePolylineOrDie(polyline_str));
   S2Error error;
   ASSERT_TRUE(builder.Build(&error));

--- a/src/s2/s2builderutil_s2polyline_vector_layer_test.cc
+++ b/src/s2/s2builderutil_s2polyline_vector_layer_test.cc
@@ -58,7 +58,7 @@ void TestS2PolylineVector(
   }
   S2Error error;
   ASSERT_TRUE(builder.Build(&error));
-  vector<string> output_strs;
+  vector<std::string> output_strs;
   for (const auto& polyline : output) {
     output_strs.push_back(s2textformat::ToString(*polyline));
   }
@@ -215,8 +215,8 @@ TEST(IndexedS2PolylineVectorLayer, AddsShapes) {
   S2Builder builder{S2Builder::Options()};
   MutableS2ShapeIndex index;
   builder.StartLayer(make_unique<IndexedS2PolylineVectorLayer>(&index));
-  string polyline0_str = "0:0, 1:1";
-  string polyline1_str = "2:2, 3:3";
+  std::string polyline0_str = "0:0, 1:1";
+  std::string polyline1_str = "2:2, 3:3";
   builder.AddPolyline(*s2textformat::MakePolylineOrDie(polyline0_str));
   builder.AddPolyline(*s2textformat::MakePolylineOrDie(polyline1_str));
   S2Error error;

--- a/src/s2/s2cell_id.cc
+++ b/src/s2/s2cell_id.cc
@@ -194,14 +194,14 @@ int S2CellId::GetCommonAncestorLevel(S2CellId other) const {
 }
 
 // Print the num_digits low order hex digits.
-static string HexFormatString(uint64 val, size_t num_digits) {
-  string result(num_digits, ' ');
+static std::string HexFormatString(uint64 val, size_t num_digits) {
+  std::string result(num_digits, ' ');
   for (; num_digits--; val >>= 4)
     result[num_digits] = "0123456789abcdef"[val & 0xF];
   return result;
 }
 
-string S2CellId::ToToken() const {
+std::string S2CellId::ToToken() const {
   // Simple implementation: print the id in hex without trailing zeros.
   // Using hex has the advantage that the tokens are case-insensitive, all
   // characters are alphanumeric, no characters require any special escaping
@@ -238,7 +238,7 @@ S2CellId S2CellId::FromToken(const char* token, size_t length) {
   return S2CellId(id);
 }
 
-S2CellId S2CellId::FromToken(const string& token) {
+S2CellId S2CellId::FromToken(const std::string& token) {
   return FromToken(token.data(), token.size());
 }
 
@@ -585,11 +585,11 @@ void S2CellId::AppendAllNeighbors(int nbr_level,
   }
 }
 
-string S2CellId::ToString() const {
+std::string S2CellId::ToString() const {
   if (!is_valid()) {
     return StrCat("Invalid: ", absl::Hex(id(), absl::kZeroPad16));
   }
-  string out = StrCat(face(), "/");
+  std::string out = StrCat(face(), "/");
   for (int current_level = 1; current_level <= level(); ++current_level) {
     // Avoid dependencies of SimpleItoA, and slowness of StrAppend &
     // std::to_string.

--- a/src/s2/s2cell_id.h
+++ b/src/s2/s2cell_id.h
@@ -362,9 +362,9 @@ class S2CellId {
   // These methods guarantee that FromToken(ToToken(x)) == x even when
   // "x" is an invalid cell id.  All tokens are alphanumeric strings.
   // FromToken() returns S2CellId::None() for malformed inputs.
-  string ToToken() const;
+  std::string ToToken() const;
   static S2CellId FromToken(const char* token, size_t length);
-  static S2CellId FromToken(const string& token);
+  static S2CellId FromToken(const std::string& token);
 
   // Use encoder to generate a serialized representation of this cell id.
   // Can also encode an invalid cell.
@@ -381,7 +381,7 @@ class S2CellId {
   //
   // For example "4/" represents S2CellId::FromFace(4), and "3/02" represents
   // S2CellId::FromFace(3).child(0).child(2).
-  string ToString() const;
+  std::string ToString() const;
 
   // Converts a string in the format returned by ToString() to an S2CellId.
   // Returns S2CellId::None() if the string could not be parsed.

--- a/src/s2/s2cell_id_test.cc
+++ b/src/s2/s2cell_id_test.cc
@@ -286,14 +286,14 @@ TEST(S2CellId, Tokens) {
   // Test random cell ids at all levels.
   for (int i = 0; i < 10000; ++i) {
     S2CellId id = S2Testing::GetRandomCellId();
-    string token = id.ToToken();
+    std::string token = id.ToToken();
     EXPECT_LE(token.size(), 16);
     EXPECT_EQ(id, S2CellId::FromToken(token));
     EXPECT_EQ(id, S2CellId::FromToken(token.data(), token.size()));
   }
   // Check that invalid cell ids can be encoded, and round-trip is
   // the identity operation.
-  string token = S2CellId::None().ToToken();
+  std::string token = S2CellId::None().ToToken();
   EXPECT_EQ(S2CellId::None(), S2CellId::FromToken(token));
   EXPECT_EQ(S2CellId::None(), S2CellId::FromToken(token.data(), token.size()));
 
@@ -630,4 +630,3 @@ TEST(S2CellId, OutputOperator) {
   s << cell;
   EXPECT_EQ("5/31200", s.str());
 }
-

--- a/src/s2/s2cell_index_test.cc
+++ b/src/s2/s2cell_index_test.cc
@@ -44,7 +44,7 @@ class S2CellIndexTest : public ::testing::Test {
     contents_.push_back(LabelledCell(cell_id, label));
   }
 
-  void Add(const string& cell_str, Label label) {
+  void Add(const std::string& cell_str, Label label) {
     Add(S2CellId::FromDebugString(cell_str), label);
   }
 
@@ -62,9 +62,9 @@ class S2CellIndexTest : public ::testing::Test {
   void VerifyRangeIterators() const;
   void VerifyIndexContents() const;
   void TestIntersection(const S2CellUnion& target);
-  void ExpectContents(const string& target_str,
+  void ExpectContents(const std::string& target_str,
                       S2CellIndex::ContentsIterator* contents,
-                      const vector<pair<string, Label>>& expected_strs) const;
+                      const vector<pair<std::string, Label>>& expected_strs) const;
 
  protected:
   S2CellIndex index_;
@@ -273,8 +273,8 @@ TEST_F(S2CellIndexTest, RandomCellUnions) {
 // first leaf cell contained by this target will intersect the exact set of
 // (cell_id, label) pairs given by "expected_strs".
 void S2CellIndexTest::ExpectContents(
-    const string& target_str, S2CellIndex::ContentsIterator* contents,
-    const vector<pair<string, Label>>& expected_strs) const {
+    const std::string& target_str, S2CellIndex::ContentsIterator* contents,
+    const vector<pair<std::string, Label>>& expected_strs) const {
   S2CellIndex::RangeIterator range(&index_);
   range.Seek(S2CellId::FromDebugString(target_str).range_min());
   vector<LabelledCell> expected, actual;
@@ -354,7 +354,7 @@ void S2CellIndexTest::TestIntersection(const S2CellUnion& target) {
             actual_labels);
 }
 
-S2CellUnion MakeCellUnion(const vector<string>& strs) {
+S2CellUnion MakeCellUnion(const vector<std::string>& strs) {
   vector<S2CellId> ids;
   for (const auto& str : strs) {
     ids.push_back(S2CellId::FromDebugString(str));

--- a/src/s2/s2crossing_edge_query_test.cc
+++ b/src/s2/s2crossing_edge_query_test.cc
@@ -146,7 +146,7 @@ void TestAllCrossings(const vector<TestEdge>& edges) {
     EXPECT_GE(candidates.front().edge_id, 0);
     EXPECT_LT(candidates.back().edge_id, shape->num_edges());
     num_candidates += candidates.size();
-    string missing_candidates;
+    std::string missing_candidates;
     vector<ShapeEdgeId> expected_crossings, expected_interior_crossings;
     for (int i = 0; i < shape->num_edges(); ++i) {
       auto edge = shape->edge(i);

--- a/src/s2/s2earth_test.cc
+++ b/src/s2/s2earth_test.cc
@@ -86,7 +86,7 @@ TEST(S2EarthTest, TestToLongitudeRadians) {
 
 TEST(S2EarthTest, TestGetInitialBearing) {
   struct TestConfig {
-    string description;
+    std::string description;
     S2LatLng a;
     S2LatLng b;
     S1Angle bearing;

--- a/src/s2/s2edge_distances_test.cc
+++ b/src/s2/s2edge_distances_test.cc
@@ -467,7 +467,7 @@ TEST(S2, EdgePairMaxDistance) {
                            M_PI);
 }
 
-bool IsEdgeBNearEdgeA(const string& a_str, const string& b_str,
+bool IsEdgeBNearEdgeA(const std::string& a_str, const std::string& b_str,
                       double max_error_degrees) {
   unique_ptr<S2Polyline> a(s2textformat::MakePolyline(a_str));
   EXPECT_EQ(2, a->num_vertices());

--- a/src/s2/s2edge_tessellator_test.cc
+++ b/src/s2/s2edge_tessellator_test.cc
@@ -54,7 +54,7 @@ class Stats {
   double max() const { return max_; }
   double avg() const { return sum_ / count_; }
 
-  string ToString() const {
+  std::string ToString() const {
     return StrCat("avg = ", sum_ / count_, ", max = ", max_);
   }
 

--- a/src/s2/s2error.h
+++ b/src/s2/s2error.h
@@ -121,14 +121,14 @@ class S2Error {
 
   bool ok() const { return code_ == OK; }
   Code code() const { return code_; }
-  string text() const { return text_; }
+  std::string text() const { return text_; }
 
   // Clear the error to contain the OK code and no error message.
   void Clear();
 
  private:
   Code code_;
-  string text_;
+  std::string text_;
 };
 
 

--- a/src/s2/s2latlng.cc
+++ b/src/s2/s2latlng.cc
@@ -76,12 +76,12 @@ S1Angle S2LatLng::GetDistance(const S2LatLng& o) const {
   return S1Angle::Radians(2 * asin(sqrt(min(1.0, x))));
 }
 
-string S2LatLng::ToStringInDegrees() const {
+std::string S2LatLng::ToStringInDegrees() const {
   S2LatLng pt = Normalized();
   return StringPrintf("%f,%f", pt.lat().degrees(), pt.lng().degrees());
 }
 
-void S2LatLng::ToStringInDegrees(string* s) const {
+void S2LatLng::ToStringInDegrees(std::string* s) const {
   *s = ToStringInDegrees();
 }
 

--- a/src/s2/s2latlng.h
+++ b/src/s2/s2latlng.h
@@ -130,8 +130,8 @@ class S2LatLng {
 
   // Exports the latitude and longitude in degrees, separated by a comma.
   // e.g. "94.518000,150.300000"
-  string ToStringInDegrees() const;
-  void ToStringInDegrees(string* s) const;
+  std::string ToStringInDegrees() const;
+  void ToStringInDegrees(std::string* s) const;
 
  private:
   // Internal constructor.

--- a/src/s2/s2latlng_test.cc
+++ b/src/s2/s2latlng_test.cc
@@ -131,7 +131,7 @@ TEST(S2LatLng, TestToString) {
   for (const auto& v : values) {
     SCOPED_TRACE(StrCat("Iteration ", i++));
     S2LatLng p = S2LatLng::FromDegrees(v.lat, v.lng);
-    string output;
+    std::string output;
     p.ToStringInDegrees(&output);
 
     double lat, lng;
@@ -143,7 +143,7 @@ TEST(S2LatLng, TestToString) {
 
 // Test the variant that returns a string.
 TEST(S2LatLng, TestToStringReturnsString) {
-  string s;
+  std::string s;
   S2LatLng::FromDegrees(0, 1).ToStringInDegrees(&s);
   EXPECT_EQ(S2LatLng::FromDegrees(0, 1).ToStringInDegrees(), s);
 }
@@ -162,4 +162,3 @@ TEST(S2LatLng, TestHashCode) {
   EXPECT_EQ(4, map[S2LatLng::FromDegrees(7, 17)]);
   EXPECT_EQ(5, map[S2LatLng::FromDegrees(11, 19)]);
 }
-

--- a/src/s2/s2loop_measures_test.cc
+++ b/src/s2/s2loop_measures_test.cc
@@ -39,7 +39,7 @@ namespace {
 // "abac"), returns a vector of S2Points of the form (ch, 0, 0).  Note that
 // these points are not unit length and therefore are not suitable for general
 // use, however they are useful for testing certain functions below.
-vector<S2Point> MakeTestLoop(const string& loop_str) {
+vector<S2Point> MakeTestLoop(const std::string& loop_str) {
   vector<S2Point> loop;
   for (char ch : loop_str) {
     loop.push_back(S2Point(ch, 0, 0));
@@ -49,11 +49,11 @@ vector<S2Point> MakeTestLoop(const string& loop_str) {
 
 // Given a loop whose vertices are represented as characters (such as "abcd" or
 // "abccb"), verify that S2::PruneDegeneracies() yields the loop "expected".
-void TestPruneDegeneracies(const string& input_str,
-                           const string& expected_str) {
+void TestPruneDegeneracies(const std::string& input_str,
+                           const std::string& expected_str) {
   vector<S2Point> input = MakeTestLoop(input_str);
   vector<S2Point> new_vertices;
-  string actual_str;
+  std::string actual_str;
   for (const S2Point& p : S2::PruneDegeneracies(input, &new_vertices)) {
     actual_str.push_back(static_cast<char>(p[0]));
   }
@@ -88,7 +88,7 @@ TEST(PruneDegeneracies, SomeDegeneracies) {
 
 // Given a loop whose vertices are represented as characters (such as "abcd" or
 // "abccb"), verify that S2::GetCanonicalLoopOrder returns the given result.
-void TestCanonicalLoopOrder(const string& input_str,
+void TestCanonicalLoopOrder(const std::string& input_str,
                             S2::LoopOrder expected_order) {
   EXPECT_EQ(expected_order, S2::GetCanonicalLoopOrder(MakeTestLoop(input_str)));
 }

--- a/src/s2/s2loop_test.cc
+++ b/src/s2/s2loop_test.cc
@@ -100,7 +100,7 @@ class S2LoopTestBase : public testing::Test {
   unique_ptr<const S2Loop> snapped_loop_a_;
 
  private:
-  unique_ptr<const S2Loop> AddLoop(const string& str) {
+  unique_ptr<const S2Loop> AddLoop(const std::string& str) {
     return AddLoop(s2textformat::MakeLoop(str));
   }
 
@@ -1184,19 +1184,19 @@ TEST(S2Loop, S2CellConstructorAndContains) {
 
 // Construct a loop using s2textformat::MakeLoop(str) and check that it
 // produces a validation error that includes "snippet".
-static void CheckLoopIsInvalid(const string& str, const string& snippet) {
+static void CheckLoopIsInvalid(const std::string& str, const std::string& snippet) {
   unique_ptr<S2Loop> loop(s2textformat::MakeLoop(str, S2Debug::DISABLE));
   S2Error error;
   EXPECT_TRUE(loop->FindValidationError(&error));
-  EXPECT_NE(string::npos, error.text().find(snippet));
+  EXPECT_NE(std::string::npos, error.text().find(snippet));
 }
 
 static void CheckLoopIsInvalid(const vector<S2Point>& points,
-                               const string& snippet) {
+                               const std::string& snippet) {
   S2Loop l(points, S2Debug::DISABLE);
   S2Error error;
   EXPECT_TRUE(l.FindValidationError(&error));
-  EXPECT_NE(string::npos, error.text().find(snippet));
+  EXPECT_NE(std::string::npos, error.text().find(snippet));
 }
 
 TEST(S2Loop, IsValidDetectsInvalidLoops) {
@@ -1368,4 +1368,3 @@ TEST(S2LoopOwningShape, Ownership) {
   auto loop = make_unique<S2Loop>(S2Loop::kEmpty());
   S2Loop::OwningShape shape(std::move(loop));
 }
-

--- a/src/s2/s2polygon_test.cc
+++ b/src/s2/s2polygon_test.cc
@@ -81,48 +81,48 @@ using std::vector;
 // A set of nested loops around the point 0:0 (lat:lng).
 // Every vertex of kNear0 is a vertex of kNear1.
 const char kNearPoint[] = "0:0";
-const string kNear0 = "-1:0, 0:1, 1:0, 0:-1;";
-const string kNear1 = "-1:-1, -1:0, -1:1, 0:1, 1:1, 1:0, 1:-1, 0:-1;";
-const string kNear2 = "-1:-2, -2:5, 5:-2;";
-const string kNear3 = "-2:-2, -3:6, 6:-3;";
-const string kNearHemi = "0:-90, -90:0, 0:90, 90:0;";
+const std::string kNear0 = "-1:0, 0:1, 1:0, 0:-1;";
+const std::string kNear1 = "-1:-1, -1:0, -1:1, 0:1, 1:1, 1:0, 1:-1, 0:-1;";
+const std::string kNear2 = "-1:-2, -2:5, 5:-2;";
+const std::string kNear3 = "-2:-2, -3:6, 6:-3;";
+const std::string kNearHemi = "0:-90, -90:0, 0:90, 90:0;";
 
 // A set of nested loops around the point 0:180 (lat:lng).
 // Every vertex of kFar0 and kFar2 belongs to kFar1, and all
 // the loops except kFar2 are non-convex.
-const string kFar0 = "0:179, 1:180, 0:-179, 2:-180;";
-const string kFar1 =
+const std::string kFar0 = "0:179, 1:180, 0:-179, 2:-180;";
+const std::string kFar1 =
   "0:179, -1:179, 1:180, -1:-179, 0:-179, 3:-178, 2:-180, 3:178;";
-const string kFar2 = "3:-178, 3:178, -1:179, -1:-179;";
-const string kFar3 = "-3:-178, 4:-177, 4:177, -3:178, -2:179;";
-const string kFarHemi = "0:-90, 60:90, -60:90;";
+const std::string kFar2 = "3:-178, 3:178, -1:179, -1:-179;";
+const std::string kFar3 = "-3:-178, 4:-177, 4:177, -3:178, -2:179;";
+const std::string kFarHemi = "0:-90, 60:90, -60:90;";
 
 // A set of nested loops around the point -90:0 (lat:lng).
-const string kSouthPoint = "-89.9999:0.001";
-const string kSouth0a = "-90:0, -89.99:0.01, -89.99:0;";
-const string kSouth0b = "-90:0, -89.99:0.03, -89.99:0.02;";
-const string kSouth0c = "-90:0, -89.99:0.05, -89.99:0.04;";
-const string kSouth1 = "-90:0, -89.9:0.1, -89.9:-0.1;";
-const string kSouth2 = "-90:0, -89.8:0.2, -89.8:-0.2;";
-const string kSouthHemi = "0:-180, 0:60, 0:-60;";
+const std::string kSouthPoint = "-89.9999:0.001";
+const std::string kSouth0a = "-90:0, -89.99:0.01, -89.99:0;";
+const std::string kSouth0b = "-90:0, -89.99:0.03, -89.99:0.02;";
+const std::string kSouth0c = "-90:0, -89.99:0.05, -89.99:0.04;";
+const std::string kSouth1 = "-90:0, -89.9:0.1, -89.9:-0.1;";
+const std::string kSouth2 = "-90:0, -89.8:0.2, -89.8:-0.2;";
+const std::string kSouthHemi = "0:-180, 0:60, 0:-60;";
 
 // Two different loops that surround all the Near and Far loops except
 // for the hemispheres.
-const string kNearFar1 = "-1:-9, -9:-9, -9:9, 9:9, 9:-9, 1:-9, "
+const std::string kNearFar1 = "-1:-9, -9:-9, -9:9, 9:9, 9:-9, 1:-9, "
                          "1:-175, 9:-175, 9:175, -9:175, -9:-175, -1:-175;";
-const string kNearFar2 = "-2:15, -2:170, -8:-175, 8:-175, "
+const std::string kNearFar2 = "-2:15, -2:170, -8:-175, 8:-175, "
                          "2:170, 2:15, 8:-4, -8:-4;";
 
 // Loops that result from intersection of other loops.
-const string kFarHSouthH = "0:-180, 0:90, -60:90, 0:-90;";
+const std::string kFarHSouthH = "0:-180, 0:90, -60:90, 0:-90;";
 
 // Rectangles that form a cross, with only shared vertices, no crossing edges.
 // Optional holes outside the intersecting region.
-const string kCross1 = "-2:1, -1:1, 1:1, 2:1, 2:-1, 1:-1, -1:-1, -2:-1;";
-const string kCross1SideHole = "-1.5:0.5, -1.2:0.5, -1.2:-0.5, -1.5:-0.5;";
-const string kCross2 = "1:-2, 1:-1, 1:1, 1:2, -1:2, -1:1, -1:-1, -1:-2;";
-const string kCross2SideHole = "0.5:-1.5, 0.5:-1.2, -0.5:-1.2, -0.5:-1.5;";
-const string kCrossCenterHole = "-0.5:0.5, 0.5:0.5, 0.5:-0.5, -0.5:-0.5;";
+const std::string kCross1 = "-2:1, -1:1, 1:1, 2:1, 2:-1, 1:-1, -1:-1, -2:-1;";
+const std::string kCross1SideHole = "-1.5:0.5, -1.2:0.5, -1.2:-0.5, -1.5:-0.5;";
+const std::string kCross2 = "1:-2, 1:-1, 1:1, 1:2, -1:2, -1:1, -1:-1, -1:-2;";
+const std::string kCross2SideHole = "0.5:-1.5, 0.5:-1.2, -0.5:-1.2, -0.5:-1.5;";
+const std::string kCrossCenterHole = "-0.5:0.5, 0.5:0.5, 0.5:-0.5, -0.5:-0.5;";
 
 // Two rectangles that intersect, but no edges cross and there's always
 // local containment (rather than crossing) at each shared vertex.
@@ -130,18 +130,18 @@ const string kCrossCenterHole = "-0.5:0.5, 0.5:0.5, 0.5:-0.5, -0.5:-0.5;";
 //      +---+---+---+
 //      | A | B | C |
 //      +---+---+---+
-const string kOverlap1 = "0:1, 1:1, 2:1, 2:0, 1:0, 0:0;";
-const string kOverlap1SideHole = "0.2:0.8, 0.8:0.8, 0.8:0.2, 0.2:0.2;";
-const string kOverlap2 = "1:1, 2:1, 3:1, 3:0, 2:0, 1:0;";
-const string kOverlap2SideHole = "2.2:0.8, 2.8:0.8, 2.8:0.2, 2.2:0.2;";
-const string kOverlapCenterHole = "1.2:0.8, 1.8:0.8, 1.8:0.2, 1.2:0.2;";
+const std::string kOverlap1 = "0:1, 1:1, 2:1, 2:0, 1:0, 0:0;";
+const std::string kOverlap1SideHole = "0.2:0.8, 0.8:0.8, 0.8:0.2, 0.2:0.2;";
+const std::string kOverlap2 = "1:1, 2:1, 3:1, 3:0, 2:0, 1:0;";
+const std::string kOverlap2SideHole = "2.2:0.8, 2.8:0.8, 2.8:0.2, 2.2:0.2;";
+const std::string kOverlapCenterHole = "1.2:0.8, 1.8:0.8, 1.8:0.2, 1.2:0.2;";
 
 // An empty polygon.
-const string kEmpty = "";
+const std::string kEmpty = "";
 // By symmetry, the intersection of the two polygons has almost half the area
 // of either polygon.
-const string kOverlap3 = "-10:10, 0:10, 0:-10, -10:-10, -10:0";
-const string kOverlap4 = "-10:0, 10:0, 10:-10, -10:-10";
+const std::string kOverlap3 = "-10:10, 0:10, 0:-10, -10:-10, -10:0";
+const std::string kOverlap4 = "-10:0, 10:0, 10:-10, -10:-10";
 
 class S2PolygonTestBase : public testing::Test {
  public:
@@ -205,7 +205,7 @@ static bool TestEncodeDecode(const S2Polygon* src) {
   return src->Equals(&dst);
 }
 
-static unique_ptr<S2Polygon> MakePolygon(const string& str) {
+static unique_ptr<S2Polygon> MakePolygon(const std::string& str) {
   unique_ptr<S2Polygon> polygon(s2textformat::MakeVerbatimPolygon(str));
 
   // Check that InitToSnapped() is idempotent.
@@ -219,7 +219,7 @@ static unique_ptr<S2Polygon> MakePolygon(const string& str) {
   return polygon;
 }
 
-static void CheckContains(const string& a_str, const string& b_str) {
+static void CheckContains(const std::string& a_str, const std::string& b_str) {
   unique_ptr<S2Polygon> a = MakePolygon(a_str);
   unique_ptr<S2Polygon> b = MakePolygon(b_str);
   EXPECT_TRUE(a->Contains(b.get()));
@@ -227,7 +227,7 @@ static void CheckContains(const string& a_str, const string& b_str) {
   EXPECT_FALSE(a->ApproxDisjoint(b.get(), S1Angle::Radians(1e-15)));
 }
 
-static void CheckContainsPoint(const string& a_str, const string& b_str) {
+static void CheckContainsPoint(const std::string& a_str, const std::string& b_str) {
   unique_ptr<S2Polygon> a(s2textformat::MakePolygon(a_str));
   EXPECT_TRUE(a->Contains(s2textformat::MakePoint(b_str)))
     << " " << a_str << " did not contain " << b_str;
@@ -2270,7 +2270,7 @@ class IsValidTest : public testing::Test {
     vloops_.clear();
   }
 
-  void CheckInvalid(const string& snippet) {
+  void CheckInvalid(const std::string& snippet) {
     vector<unique_ptr<S2Loop>> loops;
     for (const auto& vloop : vloops_) {
       loops.push_back(make_unique<S2Loop>(*vloop, S2Debug::DISABLE));
@@ -2290,7 +2290,7 @@ class IsValidTest : public testing::Test {
     if (modify_polygon_hook_) (*modify_polygon_hook_)(&polygon);
     S2Error error;
     EXPECT_TRUE(polygon.FindValidationError(&error));
-    EXPECT_TRUE(error.text().find(snippet) != string::npos)
+    EXPECT_TRUE(error.text().find(snippet) != std::string::npos)
         << "\nActual error: " << error << "\nExpected substring: " << snippet;
     Reset();
   }
@@ -2571,7 +2571,7 @@ class S2PolygonSimplifierTest : public ::testing::Test {
                                      S1Angle::Degrees(tolerance_in_degrees)));
   }
 
-  void SetInput(const string& poly, double tolerance_in_degrees) {
+  void SetInput(const std::string& poly, double tolerance_in_degrees) {
     SetInput(s2textformat::MakePolygon(poly), tolerance_in_degrees);
   }
 
@@ -2621,10 +2621,10 @@ TEST_F(S2PolygonSimplifierTest, EdgeSplitInManyPieces) {
   // near_square's right four-point side will be simplified to a vertical
   // line at lng=7.9, that will cut the 9 teeth of the saw (the edge will
   // therefore be broken into 19 pieces).
-  const string saw =
+  const std::string saw =
       "1:1, 1:8, 2:2, 2:8, 3:2, 3:8, 4:2, 4:8, 5:2, 5:8,"
       "6:2, 6:8, 7:2, 7:8, 8:2, 8:8, 9:2, 9:8, 10:1";
-  const string near_square =
+  const std::string near_square =
       "0:0, 0:7.9, 1:8.1, 10:8.1, 11:7.9, 11:0";
   SetInput(saw + ";" + near_square, 0.21);
 
@@ -2776,7 +2776,7 @@ TEST(InitToSimplifiedInCell, InteriorEdgesSnappedToBoundary) {
 
 
 unique_ptr<S2Polygon> MakeRegularPolygon(
-    const string& center, int num_points, double radius_in_degrees) {
+    const std::string& center, int num_points, double radius_in_degrees) {
   S1Angle radius = S1Angle::Degrees(radius_in_degrees);
   return make_unique<S2Polygon>(S2Loop::MakeRegularLoop(
       s2textformat::MakePoint(center), radius, num_points));
@@ -3022,4 +3022,3 @@ TEST_F(S2PolygonTestBase, PolygonPolygonDistance) {
   S1ChordAngle distance = query.GetDistance(&target);
   EXPECT_GT(distance, S1ChordAngle(S1Angle::Degrees(175)));
 }
-

--- a/src/s2/s2polyline_alignment.cc
+++ b/src/s2/s2polyline_alignment.cc
@@ -102,7 +102,7 @@ Window Window::Dilate(const int radius) const {
 }
 
 // Debug string implemented primarily for testing purposes.
-string Window::DebugString() const {
+std::string Window::DebugString() const {
   std::stringstream buffer;
   for (int row = 0; row < rows_; ++row) {
     for (int col = 0; col < cols_; ++col) {

--- a/src/s2/s2polyline_alignment_internal.h
+++ b/src/s2/s2polyline_alignment_internal.h
@@ -137,7 +137,7 @@ class Window {
   Window Dilate(const int radius) const;
 
   // Return a string representation of this window.
-  string DebugString() const;
+  std::string DebugString() const;
 
  private:
   int rows_;

--- a/src/s2/s2polyline_alignment_test.cc
+++ b/src/s2/s2polyline_alignment_test.cc
@@ -73,7 +73,7 @@ TEST(S2PolylineAlignmentTest, CreatesWindowFromWarpPath) {
 TEST(S2PolylineAlignmentTest, GeneratesWindowDebugString) {
   const std::vector<ColumnStride> strides = {{0, 4}, {0, 4}, {0, 4}, {0, 4}};
   const Window w(strides);
-  const string expected_output = R"(
+  const std::string expected_output = R"(
  * * * *
  * * * *
  * * * *
@@ -93,7 +93,7 @@ TEST(S2PolylineAlignmentTest, UpsamplesWindowByFactorOfTwo) {
       {0, 3}, {1, 4}, {2, 4}, {3, 6}, {4, 6}};
   const Window w(strides);
   const Window w_upscaled = w.Upsample(10, 12);
-  const string expected_output = R"(
+  const std::string expected_output = R"(
  * * * * * * . . . . . .
  * * * * * * . . . . . .
  . . * * * * * * . . . .
@@ -118,7 +118,7 @@ TEST(S2PolylineAlignmentTest, UpsamplesWindowXAxisByFactorOfThree) {
       {0, 3}, {1, 4}, {2, 4}, {3, 6}, {4, 6}};
   const Window w(strides);
   const Window w_upscaled = w.Upsample(5, 18);
-  const string expected_output = R"(
+  const std::string expected_output = R"(
  * * * * * * * * * . . . . . . . . .
  . . . * * * * * * * * * . . . . . .
  . . . . . . * * * * * * . . . . . .
@@ -139,7 +139,7 @@ TEST(S2PolylineAlignmentTest, UpsamplesWindowYAxisByFactorOfThree) {
       {0, 3}, {1, 4}, {2, 4}, {3, 6}, {4, 6}};
   const Window w(strides);
   const Window w_upscaled = w.Upsample(15, 6);
-  const string expected_output = R"(
+  const std::string expected_output = R"(
  * * * . . .
  * * * . . .
  * * * . . .
@@ -171,7 +171,7 @@ TEST(S2PolylineAlignmentTest, UpsamplesWindowByNonInteger) {
   const Window w(strides);
 
   const Window w_upscaled = w.Upsample(19, 23);
-  const string expected_output = R"(
+  const std::string expected_output = R"(
  * * * * * * * * * * * * . . . . . . . . . . .
  * * * * * * * * * * * * . . . . . . . . . . .
  * * * * * * * * * * * * . . . . . . . . . . .
@@ -206,7 +206,7 @@ TEST(S2PolylineAlignmentTest, DilatesWindowByRadiusZero) {
       {0, 3}, {2, 3}, {2, 3}, {2, 4}, {3, 6}};
   const Window w(strides);
   const Window w_d = w.Dilate(0);
-  const string expected_output = R"(
+  const std::string expected_output = R"(
  * * * . . .
  . . * . . .
  . . * . . .
@@ -227,7 +227,7 @@ TEST(S2PolylineAlignmentTest, DilatesWindowByRadiusOne) {
       {0, 3}, {2, 3}, {2, 3}, {2, 4}, {3, 6}};
   const Window w(strides);
   const Window w_d = w.Dilate(1);
-  const string expected_output = R"(
+  const std::string expected_output = R"(
  * * * * . .
  * * * * . .
  . * * * * .
@@ -248,7 +248,7 @@ TEST(S2PolylineAlignmentTest, DilatesWindowByRadiusTwo) {
       {0, 3}, {2, 3}, {2, 3}, {2, 4}, {3, 6}};
   const Window w(strides);
   const Window w_d = w.Dilate(2);
-  const string expected_output = R"(
+  const std::string expected_output = R"(
  * * * * * .
  * * * * * *
  * * * * * *
@@ -262,7 +262,7 @@ TEST(S2PolylineAlignmentTest, DilatesWindowByVeryLargeRadius) {
       {0, 3}, {2, 3}, {2, 3}, {2, 4}, {3, 6}};
   const Window w(strides);
   const Window w_d = w.Dilate(100);
-  const string expected_output = R"(
+  const std::string expected_output = R"(
  * * * * * *
  * * * * * *
  * * * * * *

--- a/src/s2/s2polyline_test.cc
+++ b/src/s2/s2polyline_test.cc
@@ -45,7 +45,7 @@ using std::vector;
 namespace {
 
 // Wraps s2textformat::MakePolyline in order to test Encode/Decode.
-unique_ptr<S2Polyline> MakePolyline(const string& str,
+unique_ptr<S2Polyline> MakePolyline(const std::string& str,
                                     S2Debug debug_override = S2Debug::ALLOW) {
   unique_ptr<S2Polyline> polyline =
       s2textformat::MakePolyline(str, debug_override);
@@ -301,8 +301,8 @@ TEST(S2Polyline, SpaceUsedNonEmptyPolyline)  {
   EXPECT_GT(line->SpaceUsed(), 3 * sizeof(S2Point));
 }
 
-static string JoinInts(const vector<int>& ints) {
-  string result;
+static std::string JoinInts(const vector<int>& ints) {
+  std::string result;
   int n = ints.size();
   for (int i = 0; i + 1 < n; ++i) {
     absl::StrAppend(&result, ints[i], ",");
@@ -450,7 +450,7 @@ TEST(S2PolylineOwningShape, Ownership) {
   S2Polyline::OwningShape shape(std::move(polyline));
 }
 
-void TestNearlyCovers(const string& a_str, const string& b_str,
+void TestNearlyCovers(const std::string& a_str, const std::string& b_str,
                       double max_error_degrees, bool expect_b_covers_a,
                       bool expect_a_covers_b,
                       S2Debug debug_override = S2Debug::ALLOW) {
@@ -464,7 +464,7 @@ void TestNearlyCovers(const string& a_str, const string& b_str,
 }
 
 TEST(S2PolylineCoveringTest, PolylineOverlapsSelf) {
-  string pline = "1:1, 2:2, -1:10";
+  std::string pline = "1:1, 2:2, -1:10";
   TestNearlyCovers(pline, pline, 1e-10, true, true);
 }
 
@@ -494,8 +494,8 @@ TEST(S2PolylineCoveringTest, PartialOverlapOnly) {
 TEST(S2PolylineCoveringTest, ShortBacktracking) {
   // Two lines that backtrack a bit (less than 1.5 degrees) on different edges.
   // A simple greedy matching algorithm would fail on this example.
-  const string& t1 = "0:0, 0:2, 0:1, 0:4, 0:5";
-  const string& t2 = "0:0, 0:2, 0:4, 0:3, 0:5";
+  const std::string& t1 = "0:0, 0:2, 0:1, 0:4, 0:5";
+  const std::string& t2 = "0:0, 0:2, 0:4, 0:3, 0:5";
   TestNearlyCovers(t1, t2, 1.5, true, true);
   TestNearlyCovers(t1, t2, 0.5, false, false);
 }

--- a/src/s2/s2predicates_test.cc
+++ b/src/s2/s2predicates_test.cc
@@ -474,7 +474,7 @@ class PrecisionStats {
  public:
   PrecisionStats();
   void Tally(Precision precision) { ++counts_[precision]; }
-  string ToString();
+  std::string ToString();
 
  private:
   int counts_[NUM_PRECISIONS];
@@ -484,8 +484,8 @@ PrecisionStats::PrecisionStats() {
   for (int& count : counts_) count = 0;
 }
 
-string PrecisionStats::ToString() {
-  string result;
+std::string PrecisionStats::ToString() {
+  std::string result;
   int total = 0;
   for (int i = 0; i < NUM_PRECISIONS; ++i) {
     StringAppendF(&result, "%s=%6d, ", kPrecisionNames[i], counts_[i]);

--- a/src/s2/s2region_coverer_test.cc
+++ b/src/s2/s2region_coverer_test.cc
@@ -277,7 +277,7 @@ static void TestAccuracy(int max_cells) {
 TEST(S2RegionCoverer, Accuracy) {
   for (auto max_cells :
            absl::StrSplit(FLAGS_max_cells, ',', absl::SkipEmpty())) {
-    TestAccuracy(atoi32(string(max_cells).c_str()));
+    TestAccuracy(atoi32(std::string(max_cells).c_str()));
   }
 }
 
@@ -319,7 +319,7 @@ TEST(GetFastCovering, HugeFixedLevelCovering) {
   EXPECT_GE(covering.size(), 1 << 16);
 }
 
-bool IsCanonical(const vector<string>& input_str,
+bool IsCanonical(const vector<std::string>& input_str,
                  const S2RegionCoverer::Options& options) {
   vector<S2CellId> input;
   for (const auto& str : input_str) {
@@ -397,8 +397,8 @@ TEST(IsCanonical, Normalized) {
 }
 
 void TestCanonicalizeCovering(
-    const vector<string>& input_str,
-    const vector<string>& expected_str,
+    const vector<std::string>& input_str,
+    const vector<std::string>& expected_str,
     const S2RegionCoverer::Options& options) {
   vector<S2CellId> actual, expected;
   for (const auto& str : input_str) {
@@ -411,7 +411,7 @@ void TestCanonicalizeCovering(
   EXPECT_FALSE(coverer.IsCanonical(actual));
   coverer.CanonicalizeCovering(&actual);
   EXPECT_TRUE(coverer.IsCanonical(actual));
-  vector<string> actual_str;
+  vector<std::string> actual_str;
   EXPECT_EQ(expected, actual);
 }
 

--- a/src/s2/s2region_term_indexer.cc
+++ b/src/s2/s2region_term_indexer.cc
@@ -96,7 +96,7 @@ S2RegionTermIndexer::Options::Options() {
 
 void S2RegionTermIndexer::Options::set_marker_character(char ch) {
   S2_DCHECK(!std::isalnum(ch));
-  marker_ = string(1, ch);
+  marker_ = std::string(1, ch);
 }
 
 S2RegionTermIndexer::S2RegionTermIndexer(const Options& options)
@@ -110,7 +110,7 @@ S2RegionTermIndexer::S2RegionTermIndexer(S2RegionTermIndexer&&) = default;
 S2RegionTermIndexer& S2RegionTermIndexer::operator=(S2RegionTermIndexer&&) =
                                                    default;
 
-string S2RegionTermIndexer::GetTerm(TermType term_type, const S2CellId& id,
+std::string S2RegionTermIndexer::GetTerm(TermType term_type, const S2CellId& id,
                                     string_view prefix) const {
   // There are generally more ancestor terms than covering terms, so we add
   // the extra "marker" character to the covering terms to distinguish them.
@@ -121,7 +121,7 @@ string S2RegionTermIndexer::GetTerm(TermType term_type, const S2CellId& id,
   }
 }
 
-vector<string> S2RegionTermIndexer::GetIndexTerms(const S2Point& point,
+vector<std::string> S2RegionTermIndexer::GetIndexTerms(const S2Point& point,
                                                   string_view prefix) {
   // See the top of this file for an overview of the indexing strategy.
   //
@@ -133,7 +133,7 @@ vector<string> S2RegionTermIndexer::GetIndexTerms(const S2Point& point,
   // max_level() != true_max_level() (see S2RegionCoverer::Options).
 
   const S2CellId id(point);
-  vector<string> terms;
+  vector<std::string> terms;
   for (int level = options_.min_level(); level <= options_.max_level();
        level += options_.level_mod()) {
     terms.push_back(GetTerm(TermType::ANCESTOR, id.parent(level), prefix));
@@ -141,7 +141,7 @@ vector<string> S2RegionTermIndexer::GetIndexTerms(const S2Point& point,
   return terms;
 }
 
-vector<string> S2RegionTermIndexer::GetIndexTerms(const S2Region& region,
+vector<std::string> S2RegionTermIndexer::GetIndexTerms(const S2Region& region,
                                                   string_view prefix) {
   // Note that options may have changed since the last call.
   *coverer_.mutable_options() = options_;
@@ -149,7 +149,7 @@ vector<string> S2RegionTermIndexer::GetIndexTerms(const S2Region& region,
   return GetIndexTermsForCanonicalCovering(covering, prefix);
 }
 
-vector<string> S2RegionTermIndexer::GetIndexTermsForCanonicalCovering(
+vector<std::string> S2RegionTermIndexer::GetIndexTermsForCanonicalCovering(
     const S2CellUnion& covering, string_view prefix) {
   // See the top of this file for an overview of the indexing strategy.
   //
@@ -165,7 +165,7 @@ vector<string> S2RegionTermIndexer::GetIndexTermsForCanonicalCovering(
     *coverer_.mutable_options() = options_;
     S2_CHECK(coverer_.IsCanonical(covering));
   }
-  vector<string> terms;
+  vector<std::string> terms;
   S2CellId prev_id = S2CellId::None();
   int true_max_level = options_.true_max_level();
   for (S2CellId id : covering) {
@@ -198,12 +198,12 @@ vector<string> S2RegionTermIndexer::GetIndexTermsForCanonicalCovering(
   return terms;
 }
 
-vector<string> S2RegionTermIndexer::GetQueryTerms(const S2Point& point,
+vector<std::string> S2RegionTermIndexer::GetQueryTerms(const S2Point& point,
                                                   string_view prefix) {
   // See the top of this file for an overview of the indexing strategy.
 
   const S2CellId id(point);
-  vector<string> terms;
+  vector<std::string> terms;
   // Recall that all true_max_level() cells are indexed only as ancestor terms.
   int level = options_.true_max_level();
   terms.push_back(GetTerm(TermType::ANCESTOR, id.parent(level), prefix));
@@ -216,7 +216,7 @@ vector<string> S2RegionTermIndexer::GetQueryTerms(const S2Point& point,
   return terms;
 }
 
-vector<string> S2RegionTermIndexer::GetQueryTerms(const S2Region& region,
+vector<std::string> S2RegionTermIndexer::GetQueryTerms(const S2Region& region,
                                                   string_view prefix) {
   // Note that options may have changed since the last call.
   *coverer_.mutable_options() = options_;
@@ -224,7 +224,7 @@ vector<string> S2RegionTermIndexer::GetQueryTerms(const S2Region& region,
   return GetQueryTermsForCanonicalCovering(covering, prefix);
 }
 
-vector<string> S2RegionTermIndexer::GetQueryTermsForCanonicalCovering(
+vector<std::string> S2RegionTermIndexer::GetQueryTermsForCanonicalCovering(
     const S2CellUnion& covering, string_view prefix) {
   // See the top of this file for an overview of the indexing strategy.
 
@@ -232,7 +232,7 @@ vector<string> S2RegionTermIndexer::GetQueryTermsForCanonicalCovering(
     *coverer_.mutable_options() = options_;
     S2_CHECK(coverer_.IsCanonical(covering));
   }
-  vector<string> terms;
+  vector<std::string> terms;
   S2CellId prev_id = S2CellId::None();
   int true_max_level = options_.true_max_level();
   for (S2CellId id : covering) {

--- a/src/s2/s2region_term_indexer.h
+++ b/src/s2/s2region_term_indexer.h
@@ -215,14 +215,14 @@ class S2RegionTermIndexer {
     //
     // REQUIRES: "ch" is non-alphanumeric.
     // DEFAULT: '$'
-    const string& marker() const { return marker_; }
+    const std::string& marker() const { return marker_; }
     char marker_character() const { return marker_[0]; }
     void set_marker_character(char ch);
 
    private:
     bool points_only_ = false;
     bool optimize_for_space_ = false;
-    string marker_ = string(1, '$');
+    std::string marker_ = std::string(1, '$');
   };
 
   // Default constructor.  Options can be set using mutable_options().
@@ -250,7 +250,7 @@ class S2RegionTermIndexer {
   // multiple types of location information (e.g. store footprint, entrances,
   // parking lots, etc).  The prefix should be kept short since it is
   // prepended to every term.
-  std::vector<string> GetIndexTerms(const S2Region& region,
+  std::vector<std::string> GetIndexTerms(const S2Region& region,
                                     absl::string_view prefix);
 
   // Converts a given query region into a set of terms.  If you compute the
@@ -258,7 +258,7 @@ class S2RegionTermIndexer {
   // include all documents whose index region intersects the query region.
   //
   // "prefix" should match the corresponding value used when indexing.
-  std::vector<string> GetQueryTerms(const S2Region& region,
+  std::vector<std::string> GetQueryTerms(const S2Region& region,
                                     absl::string_view prefix);
 
   // Convenience methods that accept an S2Point rather than S2Region.  (These
@@ -266,9 +266,9 @@ class S2RegionTermIndexer {
   //
   // Note that you can index an S2LatLng by converting it to an S2Point first:
   //     auto terms = GetIndexTerms(S2Point(latlng), ...);
-  std::vector<string> GetIndexTerms(const S2Point& point,
+  std::vector<std::string> GetIndexTerms(const S2Point& point,
                                     absl::string_view prefix);
-  std::vector<string> GetQueryTerms(const S2Point& point,
+  std::vector<std::string> GetQueryTerms(const S2Point& point,
                                     absl::string_view prefix);
 
   // Low-level methods that accept an S2CellUnion covering of the region to be
@@ -281,15 +281,15 @@ class S2RegionTermIndexer {
   // you can either call the regular S2Region methods (since S2CellUnion is a
   // type of S2Region), or "canonicalize" the covering first by calling
   // S2RegionCoverer::CanonicalizeCovering() with the same options.
-  std::vector<string> GetIndexTermsForCanonicalCovering(
+  std::vector<std::string> GetIndexTermsForCanonicalCovering(
       const S2CellUnion& covering, absl::string_view prefix);
-  std::vector<string> GetQueryTermsForCanonicalCovering(
+  std::vector<std::string> GetQueryTermsForCanonicalCovering(
       const S2CellUnion& covering, absl::string_view prefix);
 
  private:
   enum TermType { ANCESTOR, COVERING };
 
-  string GetTerm(TermType term_type, const S2CellId& id,
+  std::string GetTerm(TermType term_type, const S2CellId& id,
                  absl::string_view prefix) const;
 
   Options options_;

--- a/src/s2/s2region_term_indexer_test.cc
+++ b/src/s2/s2region_term_indexer_test.cc
@@ -52,13 +52,13 @@ void TestRandomCaps(const S2RegionTermIndexer::Options& options,
   S2RegionCoverer coverer(options);
   vector<S2Cap> caps;
   vector<S2CellUnion> coverings;
-  std::unordered_map<string, vector<int>> index;
+  std::unordered_map<std::string, vector<int>> index;
   int index_terms = 0, query_terms = 0;
   for (int i = 0; i < FLAGS_iters; ++i) {
     // Choose the region to be indexed: either a single point or a cap
     // of random size (up to a full sphere).
     S2Cap cap;
-    vector<string> terms;
+    vector<std::string> terms;
     if (options.index_contains_points_only()) {
       cap = S2Cap::FromPoint(S2Testing::RandomPoint());
       terms = indexer.GetIndexTerms(cap.center(), "");
@@ -70,7 +70,7 @@ void TestRandomCaps(const S2RegionTermIndexer::Options& options,
     }
     caps.push_back(cap);
     coverings.push_back(coverer.GetCovering(cap));
-    for (const string& term : terms) {
+    for (const std::string& term : terms) {
       index[term].push_back(i);
     }
     index_terms += terms.size();
@@ -79,7 +79,7 @@ void TestRandomCaps(const S2RegionTermIndexer::Options& options,
     // Choose the region to be queried: either a random point or a cap of
     // random size.
     S2Cap cap;
-    vector<string> terms;
+    vector<std::string> terms;
     if (query_type == QueryType::CAP) {
       cap = S2Cap::FromPoint(S2Testing::RandomPoint());
       terms = indexer.GetQueryTerms(cap.center(), "");
@@ -97,7 +97,7 @@ void TestRandomCaps(const S2RegionTermIndexer::Options& options,
         expected.insert(j);
       }
     }
-    for (const string& term : terms) {
+    for (const std::string& term : terms) {
       actual.insert(index[term].begin(), index[term].end());
     }
     EXPECT_EQ(expected, actual);

--- a/src/s2/s2region_test.cc
+++ b/src/s2/s2region_test.cc
@@ -198,10 +198,10 @@ const char kEncodedPolyline3Segments[] =
 //////////////////////////////////////////////////////////////
 
 // HexEncodeStr returns the data in str in hex encoded form.
-const string HexEncodeStr(const string& str) {
+const std::string HexEncodeStr(const std::string& str) {
   static const char* const lut = "0123456789ABCDEF";
 
-  string result;
+  std::string result;
   result.reserve(2 * str.size());
   for (size_t i = 0; i < str.length(); ++i) {
     const unsigned char c = str[i];
@@ -216,11 +216,11 @@ class S2RegionEncodeDecodeTest : public testing::Test {
   // TestEncodeDecode tests that the input encodes to match the expected
   // golden data, and then returns the decode of the data into dst.
   template <class Region>
-  void TestEncodeDecode(const string& golden, const Region& src, Region* dst) {
+  void TestEncodeDecode(const std::string& golden, const Region& src, Region* dst) {
     Encoder encoder;
     src.Encode(&encoder);
 
-    EXPECT_EQ(golden, HexEncodeStr(string(encoder.base(), encoder.length())));
+    EXPECT_EQ(golden, HexEncodeStr(std::string(encoder.base(), encoder.length())));
 
     Decoder decoder(encoder.base(), encoder.length());
     dst->Decode(&decoder);
@@ -297,8 +297,8 @@ TEST_F(S2RegionEncodeDecodeTest, S2LatLngRect) {
 }
 
 TEST_F(S2RegionEncodeDecodeTest, S2Loop) {
-  const string kCross1 = "-2:1, -1:1, 1:1, 2:1, 2:-1, 1:-1, -1:-1, -2:-1";
-  const string kCrossCenterHole = "-0.5:0.5, 0.5:0.5, 0.5:-0.5, -0.5:-0.5;";
+  const std::string kCross1 = "-2:1, -1:1, 1:1, 2:1, 2:-1, 1:-1, -1:-1, -2:-1";
+  const std::string kCrossCenterHole = "-0.5:0.5, 0.5:0.5, 0.5:-0.5, -0.5:-0.5;";
 
   S2Loop loop;
   S2Loop loop_empty(S2Loop::kEmpty());
@@ -324,8 +324,8 @@ TEST_F(S2RegionEncodeDecodeTest, S2PointRegion) {
 }
 
 TEST_F(S2RegionEncodeDecodeTest, S2Polygon) {
-  const string kCross1 = "-2:1, -1:1, 1:1, 2:1, 2:-1, 1:-1, -1:-1, -2:-1";
-  const string kCrossCenterHole = "-0.5:0.5, 0.5:0.5, 0.5:-0.5, -0.5:-0.5;";
+  const std::string kCross1 = "-2:1, -1:1, 1:1, 2:1, 2:-1, 1:-1, -1:-1, -2:-1";
+  const std::string kCrossCenterHole = "-0.5:0.5, 0.5:0.5, 0.5:-0.5, -0.5:-0.5;";
 
   S2Polygon polygon;
   unique_ptr<S2Polygon> polygon_empty = s2textformat::MakePolygon("");

--- a/src/s2/s2shape_index_buffered_region_test.cc
+++ b/src/s2/s2shape_index_buffered_region_test.cc
@@ -106,7 +106,7 @@ TEST(S2ShapeIndexBufferedRegion, BufferedPointVsCap) {
 //
 // The "radius" parameter is an S1Angle for convenience.
 // TODO(ericv): Add Degrees, Radians, etc, methods to S1ChordAngle?
-void TestBufferIndex(const string& index_str, S1Angle radius_angle,
+void TestBufferIndex(const std::string& index_str, S1Angle radius_angle,
                      S2RegionCoverer* coverer) {
   auto index = MakeIndexOrDie(index_str);
   S1ChordAngle radius(radius_angle);

--- a/src/s2/s2shape_index_region_test.cc
+++ b/src/s2/s2shape_index_region_test.cc
@@ -24,7 +24,7 @@ using std::vector;
 
 namespace {
 
-S2CellId MakeCellId(const string& str) {
+S2CellId MakeCellId(const std::string& str) {
   return S2CellId::FromDebugString(str);
 }
 

--- a/src/s2/s2shapeutil_build_polygon_boundaries_test.cc
+++ b/src/s2/s2shapeutil_build_polygon_boundaries_test.cc
@@ -29,7 +29,7 @@ namespace s2shapeutil {
 
 class TestLaxLoop : public S2LaxLoopShape {
  public:
-  explicit TestLaxLoop(const string& vertex_str) {
+  explicit TestLaxLoop(const std::string& vertex_str) {
     vector<S2Point> vertices = s2textformat::ParsePoints(vertex_str);
     Init(vertices);
   }

--- a/src/s2/s2shapeutil_edge_iterator.cc
+++ b/src/s2/s2shapeutil_edge_iterator.cc
@@ -38,7 +38,7 @@ void EdgeIterator::Next() {
   }
 }
 
-string EdgeIterator::DebugString() const {
+std::string EdgeIterator::DebugString() const {
   return absl::StrCat("(shape=", shape_id_, ", edge=", edge_id_, ")");
 }
 

--- a/src/s2/s2shapeutil_edge_iterator.h
+++ b/src/s2/s2shapeutil_edge_iterator.h
@@ -58,7 +58,7 @@ class EdgeIterator {
 
   bool operator!=(const EdgeIterator& other) const { return !(*this == other); }
 
-  string DebugString() const;
+  std::string DebugString() const;
 
  private:
   const S2ShapeIndex* index_;

--- a/src/s2/s2shapeutil_visit_crossing_edge_pairs_test.cc
+++ b/src/s2/s2shapeutil_visit_crossing_edge_pairs_test.cc
@@ -162,7 +162,7 @@ void TestHasCrossingPermutations(vector<unique_ptr<S2Loop>>* loops, int i,
 // polygon has any self-intersections or loop crossings, verify that all
 // HasSelfIntersection returns the expected result for all possible cyclic
 // permutations of the loop vertices.
-void TestHasCrossing(const string& polygon_str, bool has_crossing) {
+void TestHasCrossing(const std::string& polygon_str, bool has_crossing) {
   // Set S2Debug::DISABLE to allow invalid polygons.
   unique_ptr<S2Polygon> polygon =
       s2textformat::MakePolygonOrDie(polygon_str, S2Debug::DISABLE);

--- a/src/s2/s2testing.h
+++ b/src/s2/s2testing.h
@@ -317,7 +317,7 @@ bool CheckResultSet(const std::vector<std::pair<Distance, Id>>& x,
                     int max_size, Distance max_distance,
                     typename Distance::Delta max_error,
                     typename Distance::Delta max_pruning_error,
-                    const string& label) {
+                    const std::string& label) {
   using Result = std::pair<Distance, Id>;
   // Results should be sorted by distance, but not necessarily then by Id.
   EXPECT_TRUE(std::is_sorted(x.begin(), x.end(),

--- a/src/s2/s2text_format.cc
+++ b/src/s2/s2text_format.cc
@@ -51,7 +51,7 @@ static vector<string_view> SplitString(string_view str, char separator) {
   return result;
 }
 
-static bool ParseDouble(const string& str, double* value) {
+static bool ParseDouble(const std::string& str, double* value) {
   char* end_ptr = nullptr;
   *value = strtod(str.c_str(), &end_ptr);
   return end_ptr && *end_ptr == 0;
@@ -64,7 +64,7 @@ vector<S2LatLng> ParseLatLngsOrDie(string_view str) {
 }
 
 bool ParseLatLngs(string_view str, vector<S2LatLng>* latlngs) {
-  vector<pair<string, string>> ps;
+  vector<pair<std::string, std::string>> ps;
   if (!strings::DictionaryParse(str, &ps)) return false;
   for (const auto& p : ps) {
     double lat;
@@ -339,48 +339,48 @@ std::unique_ptr<MutableS2ShapeIndex> MakeIndex(string_view str) {
   return MakeIndexOrDie(str);
 }
 
-static void AppendVertex(const S2LatLng& ll, string* out) {
+static void AppendVertex(const S2LatLng& ll, std::string* out) {
   StringAppendF(out, "%.15g:%.15g", ll.lat().degrees(), ll.lng().degrees());
 }
 
-static void AppendVertex(const S2Point& p, string* out) {
+static void AppendVertex(const S2Point& p, std::string* out) {
   S2LatLng ll(p);
   return AppendVertex(ll, out);
 }
 
-static void AppendVertices(const S2Point* v, int n, string* out) {
+static void AppendVertices(const S2Point* v, int n, std::string* out) {
   for (int i = 0; i < n; ++i) {
     if (i > 0) *out += ", ";
     AppendVertex(v[i], out);
   }
 }
 
-string ToString(const S2Point& point) {
-  string out;
+std::string ToString(const S2Point& point) {
+  std::string out;
   AppendVertex(point, &out);
   return out;
 }
 
-string ToString(const S2LatLng& latlng) {
-  string out;
+std::string ToString(const S2LatLng& latlng) {
+  std::string out;
   AppendVertex(latlng, &out);
   return out;
 }
 
-string ToString(const S2LatLngRect& rect) {
-  string out;
+std::string ToString(const S2LatLngRect& rect) {
+  std::string out;
   AppendVertex(rect.lo(), &out);
   out += ", ";
   AppendVertex(rect.hi(), &out);
   return out;
 }
 
-string ToString(const S2CellId& cell_id) {
+std::string ToString(const S2CellId& cell_id) {
   return cell_id.ToString();
 }
 
-string ToString(const S2CellUnion& cell_union) {
-  string out;
+std::string ToString(const S2CellUnion& cell_union) {
+  std::string out;
   for (S2CellId cell_id : cell_union) {
     if (!out.empty()) out += ", ";
     out += cell_id.ToString();
@@ -388,45 +388,45 @@ string ToString(const S2CellUnion& cell_union) {
   return out;
 }
 
-string ToString(const S2Loop& loop) {
+std::string ToString(const S2Loop& loop) {
   if (loop.is_empty()) {
     return "empty";
   } else if (loop.is_full()) {
     return "full";
   }
-  string out;
+  std::string out;
   if (loop.num_vertices() > 0) {
     AppendVertices(&loop.vertex(0), loop.num_vertices(), &out);
   }
   return out;
 }
 
-string ToString(S2PointLoopSpan loop) {
+std::string ToString(S2PointLoopSpan loop) {
   // S2Shape represents the full loop as a loop with no vertices.
   // There is no representation of the empty loop.
   if (loop.empty()) {
     return "full";
   }
-  string out;
+  std::string out;
   AppendVertices(loop.data(), loop.size(), &out);
   return out;
 }
 
-string ToString(const S2Polyline& polyline) {
-  string out;
+std::string ToString(const S2Polyline& polyline) {
+  std::string out;
   if (polyline.num_vertices() > 0) {
     AppendVertices(&polyline.vertex(0), polyline.num_vertices(), &out);
   }
   return out;
 }
 
-string ToString(const S2Polygon& polygon, const char* loop_separator) {
+std::string ToString(const S2Polygon& polygon, const char* loop_separator) {
   if (polygon.is_empty()) {
     return "empty";
   } else if (polygon.is_full()) {
     return "full";
   }
-  string out;
+  std::string out;
   for (int i = 0; i < polygon.num_loops(); ++i) {
     if (i > 0) out += loop_separator;
     const S2Loop& loop = *polygon.loop(i);
@@ -435,14 +435,14 @@ string ToString(const S2Polygon& polygon, const char* loop_separator) {
   return out;
 }
 
-string ToString(const vector<S2Point>& points) {
-  string out;
+std::string ToString(const vector<S2Point>& points) {
+  std::string out;
   AppendVertices(points.data(), points.size(), &out);
   return out;
 }
 
-string ToString(const vector<S2LatLng>& latlngs) {
-  string out;
+std::string ToString(const vector<S2LatLng>& latlngs) {
+  std::string out;
   for (int i = 0; i < latlngs.size(); ++i) {
     if (i > 0) out += ", ";
     AppendVertex(latlngs[i], &out);
@@ -450,16 +450,16 @@ string ToString(const vector<S2LatLng>& latlngs) {
   return out;
 }
 
-string ToString(const S2LaxPolylineShape& polyline) {
-  string out;
+std::string ToString(const S2LaxPolylineShape& polyline) {
+  std::string out;
   if (polyline.num_vertices() > 0) {
     AppendVertices(&polyline.vertex(0), polyline.num_vertices(), &out);
   }
   return out;
 }
 
-string ToString(const S2LaxPolygonShape& polygon, const char* loop_separator) {
-  string out;
+std::string ToString(const S2LaxPolygonShape& polygon, const char* loop_separator) {
+  std::string out;
   for (int i = 0; i < polygon.num_loops(); ++i) {
     if (i > 0) out += loop_separator;
     int n = polygon.num_loop_vertices(i);
@@ -472,8 +472,8 @@ string ToString(const S2LaxPolygonShape& polygon, const char* loop_separator) {
   return out;
 }
 
-string ToString(const S2ShapeIndex& index) {
-  string out;
+std::string ToString(const S2ShapeIndex& index) {
+  std::string out;
   for (int dim = 0; dim < 3; ++dim) {
     if (dim > 0) out += "#";
     int count = 0;

--- a/src/s2/s2text_format.h
+++ b/src/s2/s2text_format.h
@@ -263,26 +263,26 @@ std::unique_ptr<MutableS2ShapeIndex> MakeIndex(absl::string_view str);
 
 // Convert an S2Point, S2LatLng, S2LatLngRect, S2CellId, S2CellUnion, loop,
 // polyline, or polygon to the string format above.
-string ToString(const S2Point& point);
-string ToString(const S2LatLng& latlng);
-string ToString(const S2LatLngRect& rect);
-string ToString(const S2CellId& cell_id);
-string ToString(const S2CellUnion& cell_union);
-string ToString(const S2Loop& loop);
-string ToString(S2PointLoopSpan loop);
-string ToString(const S2Polyline& polyline);
-string ToString(const S2Polygon& polygon, const char* loop_separator = ";\n");
-string ToString(const std::vector<S2Point>& points);
-string ToString(const std::vector<S2LatLng>& points);
-string ToString(const S2LaxPolylineShape& polyline);
-string ToString(const S2LaxPolygonShape& polygon,
+std::string ToString(const S2Point& point);
+std::string ToString(const S2LatLng& latlng);
+std::string ToString(const S2LatLngRect& rect);
+std::string ToString(const S2CellId& cell_id);
+std::string ToString(const S2CellUnion& cell_union);
+std::string ToString(const S2Loop& loop);
+std::string ToString(S2PointLoopSpan loop);
+std::string ToString(const S2Polyline& polyline);
+std::string ToString(const S2Polygon& polygon, const char* loop_separator = ";\n");
+std::string ToString(const std::vector<S2Point>& points);
+std::string ToString(const std::vector<S2LatLng>& points);
+std::string ToString(const S2LaxPolylineShape& polyline);
+std::string ToString(const S2LaxPolygonShape& polygon,
                 const char* loop_separator = ";\n");
 
 // Convert the contents of an S2ShapeIndex to the format above.  The index may
 // contain S2Shapes of any type.  Shapes are reordered if necessary so that
 // all point geometry (shapes of dimension 0) are first, followed by all
 // polyline geometry, followed by all polygon geometry.
-string ToString(const S2ShapeIndex& index);
+std::string ToString(const S2ShapeIndex& index);
 
 }  // namespace s2textformat
 

--- a/src/s2/s2text_format_test.cc
+++ b/src/s2/s2text_format_test.cc
@@ -38,12 +38,12 @@ static const int kIters = 10000;
 // Verify that s2textformat::ToString() formats the given lat/lng with at most
 // "max_digits" after the decimal point and has no trailing zeros.
 void ExpectMaxDigits(const S2LatLng& ll, int max_digits) {
-  string result = s2textformat::ToString(ll.ToPoint());
-  vector<string> values = absl::StrSplit(result, ':', absl::SkipEmpty());
+  std::string result = s2textformat::ToString(ll.ToPoint());
+  vector<std::string> values = absl::StrSplit(result, ':', absl::SkipEmpty());
   EXPECT_EQ(2, values.size()) << result;
   for (const auto& value : values) {
     int num_digits = 0;
-    if (value.find('.') != string::npos) {
+    if (value.find('.') != std::string::npos) {
       num_digits = value.size() - value.find('.') - 1;
       EXPECT_NE('0', value.back());
     }
@@ -51,7 +51,7 @@ void ExpectMaxDigits(const S2LatLng& ll, int max_digits) {
   }
 }
 
-void ExpectString(const string& expected, const S2LatLng& ll) {
+void ExpectString(const std::string& expected, const S2LatLng& ll) {
   EXPECT_EQ(expected, s2textformat::ToString(ll.ToPoint()));
 }
 
@@ -143,16 +143,16 @@ TEST(ToString, FullPolygon) {
 }
 
 TEST(ToString, S2PolygonLoopSeparator) {
-  const string kLoop1 = "0:0, 0:5, 5:0";
-  const string kLoop2 = "1:1, 1:4, 4:1";  // Shells and holes same direction.
+  const std::string kLoop1 = "0:0, 0:5, 5:0";
+  const std::string kLoop2 = "1:1, 1:4, 4:1";  // Shells and holes same direction.
   auto polygon = s2textformat::MakePolygonOrDie(kLoop1 + "; " + kLoop2);
   EXPECT_EQ(kLoop1 + ";\n" + kLoop2, s2textformat::ToString(*polygon));
   EXPECT_EQ(kLoop1 + "; " + kLoop2, s2textformat::ToString(*polygon, "; "));
 }
 
 TEST(ToString, LaxPolygonLoopSeparator) {
-  const string kLoop1 = "0:0, 0:5, 5:0";
-  const string kLoop2 = "1:1, 4:1, 1:4";  // Interior on left of all loops.
+  const std::string kLoop1 = "0:0, 0:5, 5:0";
+  const std::string kLoop2 = "1:1, 4:1, 1:4";  // Interior on left of all loops.
   auto polygon = s2textformat::MakeLaxPolygonOrDie(kLoop1 + "; " + kLoop2);
   EXPECT_EQ(kLoop1 + ";\n" + kLoop2, s2textformat::ToString(*polygon));
   EXPECT_EQ(kLoop1 + "; " + kLoop2, s2textformat::ToString(*polygon, "; "));
@@ -180,7 +180,7 @@ TEST(MakeLaxPolygon, FullWithHole) {
   EXPECT_EQ(1, shape->num_edges());
 }
 
-void TestS2ShapeIndex(const string& str) {
+void TestS2ShapeIndex(const std::string& str) {
   EXPECT_EQ(str, s2textformat::ToString(*s2textformat::MakeIndexOrDie(str)));
 }
 

--- a/src/s2/sequence_lexicon.h
+++ b/src/s2/sequence_lexicon.h
@@ -43,7 +43,7 @@
 // Example usage:
 //
 //   SequenceLexicon<string> lexicon;
-//   vector<string> pets {"cat", "dog", "parrot"};
+//   vector<std::string> pets {"cat", "dog", "parrot"};
 //   uint32 pets_id = lexicon.Add(pets);
 //   S2_CHECK_EQ(pets_id, lexicon.Add(pets));
 //   string values;

--- a/src/s2/strings/ostringstream.h
+++ b/src/s2/strings/ostringstream.h
@@ -64,7 +64,7 @@ class OStringStream : private std::basic_streambuf<char>, public std::ostream {
  public:
   // Export the same types as ostringstream does; for use info, see
   // http://en.cppreference.com/w/cpp/io/basic_ostringstream
-  typedef string::allocator_type allocator_type;
+  typedef std::string::allocator_type allocator_type;
 
   // These types are defined in both basic_streambuf and ostream, and although
   // they are identical, they cause compiler ambiguities, so we define them to
@@ -80,11 +80,11 @@ class OStringStream : private std::basic_streambuf<char>, public std::ostream {
   //
   // The destructor of OStringStream doesn't use the string. It's OK to destroy
   // the string before the stream.
-  explicit OStringStream(string* s) : std::ostream(this), s_(s) {}
+  explicit OStringStream(std::string* s) : std::ostream(this), s_(s) {}
 
-  string* str() { return s_; }
-  const string* str() const { return s_; }
-  void str(string* s) { s_ = s; }
+  std::string* str() { return s_; }
+  const std::string* str() const { return s_; }
+  void str(std::string* s) { s_ = s; }
 
   // These functions are defined in both basic_streambuf and ostream, but it's
   // ostream definition that affects the strings produced.
@@ -97,7 +97,7 @@ class OStringStream : private std::basic_streambuf<char>, public std::ostream {
   Buf::int_type overflow(int c) override;
   std::streamsize xsputn(const char* s, std::streamsize n) override;
 
-  string* s_;
+  std::string* s_;
 };
 
 }  // namespace strings

--- a/src/s2/strings/serialize.cc
+++ b/src/s2/strings/serialize.cc
@@ -24,13 +24,12 @@
 using absl::StrSplit;
 using absl::string_view;
 using std::pair;
-using std::string;
 using std::vector;
 
 namespace strings {
 
 bool DictionaryParse(string_view encoded_str,
-                     vector<pair<string, string>>* items) {
+                     vector<pair<std::string, std::string>>* items) {
   if (encoded_str.empty())
     return true;
   vector<string_view> const entries = StrSplit(encoded_str, ',');
@@ -38,7 +37,7 @@ bool DictionaryParse(string_view encoded_str,
     vector<string_view> const fields = StrSplit(entries[i], ':');
     if (fields.size() != 2)  // parsing error
       return false;
-    items->push_back(std::make_pair(string(fields[0]), string(fields[1])));
+    items->push_back(std::make_pair(std::string(fields[0]), std::string(fields[1])));
   }
   return true;
 }

--- a/src/s2/third_party/absl/base/config.h
+++ b/src/s2/third_party/absl/base/config.h
@@ -421,7 +421,7 @@
 
 // ABSL_HAVE_STD_STRING_VIEW
 //
-// Checks whether C++17 std::string_view is available.
+// Checks whether C++17 string_view is available.
 #ifdef ABSL_HAVE_STD_STRING_VIEW
 #error "ABSL_HAVE_STD_STRING_VIEW cannot be directly set."
 #endif
@@ -430,8 +430,8 @@
 #if __has_include(<string_view>) && __cplusplus >= 201703L
 #define ABSL_HAVE_STD_STRING_VIEW 1
 #endif
-// TODO(b/68770332) For now, using std::string_view is not practical.
-// This can be reversed when absl::string_view presents the std::string_view
+// TODO(b/68770332) For now, using string_view is not practical.
+// This can be reversed when absl::string_view presents the string_view
 #undef ABSL_HAVE_STD_STRING_VIEW
 #endif
 

--- a/src/s2/third_party/absl/base/port.h
+++ b/src/s2/third_party/absl/base/port.h
@@ -33,19 +33,6 @@
 // Obsolete (to be removed)
 // -----------------------------------------------------------------------------
 
-// HAS_GLOBAL_STRING
-// Some platforms have a ::string class that is different from ::std::string
-// (although the interface is the same, of course).  On other platforms,
-// ::string is the same as ::std::string.
-#if defined(__cplusplus) && !defined(SWIG)
-#include <string>
-#ifndef HAS_GLOBAL_STRING
-using std::basic_string;
-using std::string;
-// TODO(user): using std::wstring?
-#endif  // HAS_GLOBAL_STRING
-#endif  // SWIG, __cplusplus
-
 // NOTE: These live in Abseil purely as a short-term layering workaround to
 // resolve a dependency chain between util/hash/hash, absl/strings, and //base:
 // in order for //base to depend on absl/strings, the includes of hash need

--- a/src/s2/third_party/absl/container/internal/layout.h
+++ b/src/s2/third_party/absl/container/internal/layout.h
@@ -289,8 +289,8 @@ constexpr size_t Max(size_t a, size_t b, Ts... rest) {
 }
 
 template <class T>
-string TypeName() {
-  string out;
+std::string TypeName() {
+  std::string out;
   int status = 0;
   char* demangled = nullptr;
 #ifdef ABSL_INTERNAL_HAS_CXA_DEMANGLE
@@ -641,11 +641,11 @@ class LayoutImpl<std::tuple<Elements...>, absl::index_sequence<SizeSeq...>,
   // be missing (as in the example above). Only fields with known offsets are
   // described. Type names may differ across platforms: one compiler might
   // produce "unsigned*" where another produces "unsigned int *".
-  string DebugString() const {
+  std::string DebugString() const {
     const auto offsets = Offsets();
     const size_t sizes[] = {SizeOf<ElementType<OffsetSeq>>()...};
-    const string types[] = {adl_barrier::TypeName<ElementType<OffsetSeq>>()...};
-    string res = absl::StrCat("@0", types[0], "(", sizes[0], ")");
+    const std::string types[] = {adl_barrier::TypeName<ElementType<OffsetSeq>>()...};
+    std::string res = absl::StrCat("@0", types[0], "(", sizes[0], ")");
     for (size_t i = 0; i != NumOffsets - 1; ++i) {
       absl::StrAppend(&res, "[", size_[i], "]; @", offsets[i + 1], types[i + 1],
                       "(", sizes[i + 1], ")");

--- a/src/s2/third_party/absl/strings/ascii.cc
+++ b/src/s2/third_party/absl/strings/ascii.cc
@@ -154,19 +154,19 @@ const char kToUpper[256] = {
 
 }  // namespace ascii_internal
 
-void AsciiStrToLower(string* s) {
+void AsciiStrToLower(std::string* s) {
   for (auto& ch : *s) {
     ch = absl::ascii_tolower(ch);
   }
 }
 
-void AsciiStrToUpper(string* s) {
+void AsciiStrToUpper(std::string* s) {
   for (auto& ch : *s) {
     ch = absl::ascii_toupper(ch);
   }
 }
 
-void RemoveExtraAsciiWhitespace(string* str) {
+void RemoveExtraAsciiWhitespace(std::string* str) {
   auto stripped = StripAsciiWhitespace(*str);
 
   if (stripped.empty()) {

--- a/src/s2/third_party/absl/strings/ascii.h
+++ b/src/s2/third_party/absl/strings/ascii.h
@@ -163,11 +163,11 @@ inline char ascii_tolower(unsigned char c) {
 }
 
 // Converts the characters in `s` to lowercase, changing the contents of `s`.
-void AsciiStrToLower(string* s);
+void AsciiStrToLower(std::string* s);
 
 // Creates a lowercase string from a given absl::string_view.
-ABSL_MUST_USE_RESULT inline string AsciiStrToLower(absl::string_view s) {
-  string result(s);
+ABSL_MUST_USE_RESULT inline std::string AsciiStrToLower(absl::string_view s) {
+  std::string result(s);
   absl::AsciiStrToLower(&result);
   return result;
 }
@@ -181,11 +181,11 @@ inline char ascii_toupper(unsigned char c) {
 }
 
 // Converts the characters in `s` to uppercase, changing the contents of `s`.
-void AsciiStrToUpper(string* s);
+void AsciiStrToUpper(std::string* s);
 
 // Creates an uppercase string from a given absl::string_view.
-ABSL_MUST_USE_RESULT inline string AsciiStrToUpper(absl::string_view s) {
-  string result(s);
+ABSL_MUST_USE_RESULT inline std::string AsciiStrToUpper(absl::string_view s) {
+  std::string result(s);
   absl::AsciiStrToUpper(&result);
   return result;
 }
@@ -199,7 +199,7 @@ ABSL_MUST_USE_RESULT inline absl::string_view StripLeadingAsciiWhitespace(
 }
 
 // Strips in place whitespace from the beginning of the given string.
-inline void StripLeadingAsciiWhitespace(string* str) {
+inline void StripLeadingAsciiWhitespace(std::string* str) {
   auto it = std::find_if_not(str->begin(), str->end(), absl::ascii_isspace);
   str->erase(str->begin(), it);
 }
@@ -213,7 +213,7 @@ ABSL_MUST_USE_RESULT inline absl::string_view StripTrailingAsciiWhitespace(
 }
 
 // Strips in place whitespace from the end of the given string
-inline void StripTrailingAsciiWhitespace(string* str) {
+inline void StripTrailingAsciiWhitespace(std::string* str) {
   auto it = std::find_if_not(str->rbegin(), str->rend(), absl::ascii_isspace);
   str->erase(str->rend() - it);
 }
@@ -226,13 +226,13 @@ ABSL_MUST_USE_RESULT inline absl::string_view StripAsciiWhitespace(
 }
 
 // Strips in place whitespace from both ends of the given string
-inline void StripAsciiWhitespace(string* str) {
+inline void StripAsciiWhitespace(std::string* str) {
   StripTrailingAsciiWhitespace(str);
   StripLeadingAsciiWhitespace(str);
 }
 
 // Removes leading, trailing, and consecutive internal whitespace.
-void RemoveExtraAsciiWhitespace(string*);
+void RemoveExtraAsciiWhitespace(std::string*);
 
 }  // namespace absl
 

--- a/src/s2/third_party/absl/strings/str_cat.cc
+++ b/src/s2/third_party/absl/strings/str_cat.cc
@@ -93,8 +93,8 @@ static char* Append(char* out, const AlphaNum& x) {
   return after;
 }
 
-string StrCat(const AlphaNum& a, const AlphaNum& b) {
-  string result;
+std::string StrCat(const AlphaNum& a, const AlphaNum& b) {
+  std::string result;
   absl::strings_internal::STLStringResizeUninitialized(&result,
                                                        a.size() + b.size());
   char* const begin = &*result.begin();
@@ -105,8 +105,8 @@ string StrCat(const AlphaNum& a, const AlphaNum& b) {
   return result;
 }
 
-string StrCat(const AlphaNum& a, const AlphaNum& b, const AlphaNum& c) {
-  string result;
+std::string StrCat(const AlphaNum& a, const AlphaNum& b, const AlphaNum& c) {
+  std::string result;
   strings_internal::STLStringResizeUninitialized(
       &result, a.size() + b.size() + c.size());
   char* const begin = &*result.begin();
@@ -118,9 +118,9 @@ string StrCat(const AlphaNum& a, const AlphaNum& b, const AlphaNum& c) {
   return result;
 }
 
-string StrCat(const AlphaNum& a, const AlphaNum& b, const AlphaNum& c,
+std::string StrCat(const AlphaNum& a, const AlphaNum& b, const AlphaNum& c,
               const AlphaNum& d) {
-  string result;
+  std::string result;
   strings_internal::STLStringResizeUninitialized(
       &result, a.size() + b.size() + c.size() + d.size());
   char* const begin = &*result.begin();
@@ -136,8 +136,8 @@ string StrCat(const AlphaNum& a, const AlphaNum& b, const AlphaNum& c,
 namespace strings_internal {
 
 // Do not call directly - these are not part of the public API.
-string CatPieces(std::initializer_list<absl::string_view> pieces) {
-  string result;
+std::string CatPieces(std::initializer_list<absl::string_view> pieces) {
+  std::string result;
   size_t total_size = 0;
   for (const absl::string_view piece : pieces) total_size += piece.size();
   strings_internal::STLStringResizeUninitialized(&result, total_size);
@@ -162,7 +162,7 @@ string CatPieces(std::initializer_list<absl::string_view> pieces) {
   assert(((src).size() == 0) ||      \
          (uintptr_t((src).data() - (dest).data()) > uintptr_t((dest).size())))
 
-void AppendPieces(string* dest,
+void AppendPieces(std::string* dest,
                   std::initializer_list<absl::string_view> pieces) {
   size_t old_size = dest->size();
   size_t total_size = old_size;
@@ -185,15 +185,15 @@ void AppendPieces(string* dest,
 
 }  // namespace strings_internal
 
-void StrAppend(string* dest, const AlphaNum& a) {
+void StrAppend(std::string* dest, const AlphaNum& a) {
   ASSERT_NO_OVERLAP(*dest, a);
   dest->append(a.data(), a.size());
 }
 
-void StrAppend(string* dest, const AlphaNum& a, const AlphaNum& b) {
+void StrAppend(std::string* dest, const AlphaNum& a, const AlphaNum& b) {
   ASSERT_NO_OVERLAP(*dest, a);
   ASSERT_NO_OVERLAP(*dest, b);
-  string::size_type old_size = dest->size();
+  std::string::size_type old_size = dest->size();
   strings_internal::STLStringResizeUninitialized(
       dest, old_size + a.size() + b.size());
   char* const begin = &*dest->begin();
@@ -203,12 +203,12 @@ void StrAppend(string* dest, const AlphaNum& a, const AlphaNum& b) {
   assert(out == begin + dest->size());
 }
 
-void StrAppend(string* dest, const AlphaNum& a, const AlphaNum& b,
+void StrAppend(std::string* dest, const AlphaNum& a, const AlphaNum& b,
                const AlphaNum& c) {
   ASSERT_NO_OVERLAP(*dest, a);
   ASSERT_NO_OVERLAP(*dest, b);
   ASSERT_NO_OVERLAP(*dest, c);
-  string::size_type old_size = dest->size();
+  std::string::size_type old_size = dest->size();
   strings_internal::STLStringResizeUninitialized(
       dest, old_size + a.size() + b.size() + c.size());
   char* const begin = &*dest->begin();
@@ -219,13 +219,13 @@ void StrAppend(string* dest, const AlphaNum& a, const AlphaNum& b,
   assert(out == begin + dest->size());
 }
 
-void StrAppend(string* dest, const AlphaNum& a, const AlphaNum& b,
+void StrAppend(std::string* dest, const AlphaNum& a, const AlphaNum& b,
                const AlphaNum& c, const AlphaNum& d) {
   ASSERT_NO_OVERLAP(*dest, a);
   ASSERT_NO_OVERLAP(*dest, b);
   ASSERT_NO_OVERLAP(*dest, c);
   ASSERT_NO_OVERLAP(*dest, d);
-  string::size_type old_size = dest->size();
+  std::string::size_type old_size = dest->size();
   strings_internal::STLStringResizeUninitialized(
       dest, old_size + a.size() + b.size() + c.size() + d.size());
   char* const begin = &*dest->begin();

--- a/src/s2/third_party/absl/strings/str_cat.h
+++ b/src/s2/third_party/absl/strings/str_cat.h
@@ -304,27 +304,27 @@ class AlphaNum {
 namespace strings_internal {
 
 // Do not call directly - this is not part of the public API.
-string CatPieces(std::initializer_list<absl::string_view> pieces);
-void AppendPieces(string* dest,
+std::string CatPieces(std::initializer_list<absl::string_view> pieces);
+void AppendPieces(std::string* dest,
                   std::initializer_list<absl::string_view> pieces);
 
 }  // namespace strings_internal
 
-ABSL_MUST_USE_RESULT inline string StrCat() { return string(); }
+ABSL_MUST_USE_RESULT inline std::string StrCat() { return std::string(); }
 
-ABSL_MUST_USE_RESULT inline string StrCat(const AlphaNum& a) {
-  return string(a.data(), a.size());
+ABSL_MUST_USE_RESULT inline std::string StrCat(const AlphaNum& a) {
+  return std::string(a.data(), a.size());
 }
 
-ABSL_MUST_USE_RESULT string StrCat(const AlphaNum& a, const AlphaNum& b);
-ABSL_MUST_USE_RESULT string StrCat(const AlphaNum& a, const AlphaNum& b,
+ABSL_MUST_USE_RESULT std::string StrCat(const AlphaNum& a, const AlphaNum& b);
+ABSL_MUST_USE_RESULT std::string StrCat(const AlphaNum& a, const AlphaNum& b,
                                    const AlphaNum& c);
-ABSL_MUST_USE_RESULT string StrCat(const AlphaNum& a, const AlphaNum& b,
+ABSL_MUST_USE_RESULT std::string StrCat(const AlphaNum& a, const AlphaNum& b,
                                    const AlphaNum& c, const AlphaNum& d);
 
 // Support 5 or more arguments
 template <typename... AV>
-ABSL_MUST_USE_RESULT inline string StrCat(const AlphaNum& a, const AlphaNum& b,
+ABSL_MUST_USE_RESULT inline std::string StrCat(const AlphaNum& a, const AlphaNum& b,
                                           const AlphaNum& c, const AlphaNum& d,
                                           const AlphaNum& e,
                                           const AV&... args) {
@@ -360,17 +360,17 @@ ABSL_MUST_USE_RESULT inline string StrCat(const AlphaNum& a, const AlphaNum& b,
 //   absl::string_view p = s;
 //   StrAppend(&s, p);
 
-inline void StrAppend(string*) {}
-void StrAppend(string* dest, const AlphaNum& a);
-void StrAppend(string* dest, const AlphaNum& a, const AlphaNum& b);
-void StrAppend(string* dest, const AlphaNum& a, const AlphaNum& b,
+inline void StrAppend(std::string*) {}
+void StrAppend(std::string* dest, const AlphaNum& a);
+void StrAppend(std::string* dest, const AlphaNum& a, const AlphaNum& b);
+void StrAppend(std::string* dest, const AlphaNum& a, const AlphaNum& b,
                const AlphaNum& c);
-void StrAppend(string* dest, const AlphaNum& a, const AlphaNum& b,
+void StrAppend(std::string* dest, const AlphaNum& a, const AlphaNum& b,
                const AlphaNum& c, const AlphaNum& d);
 
 // Support 5 or more arguments
 template <typename... AV>
-inline void StrAppend(string* dest, const AlphaNum& a, const AlphaNum& b,
+inline void StrAppend(std::string* dest, const AlphaNum& a, const AlphaNum& b,
                       const AlphaNum& c, const AlphaNum& d, const AlphaNum& e,
                       const AV&... args) {
   strings_internal::AppendPieces(

--- a/src/s2/third_party/absl/strings/str_split.cc
+++ b/src/s2/third_party/absl/strings/str_split.cc
@@ -31,7 +31,7 @@ vector<String> StrSplit(String const& text, char const delim,
     elems.emplace_back(view);
   return elems;
 }
-template vector<string> StrSplit(string const& text, char const delim,
+template vector<std::string> StrSplit(string const& text, char const delim,
                                  function<bool(string_view)> predicate);
 template vector<string_view> StrSplit(string_view const& text, char const delim,
                                       function<bool(string_view)> predicate);
@@ -40,7 +40,7 @@ template <typename String>
 vector<String> StrSplit(String const& text, char const delim) {
   return StrSplit(text, delim, [](string_view) { return true; });
 }
-template vector<string> StrSplit(string const& text, char const delim);
+template vector<std::string> StrSplit(string const& text, char const delim);
 template vector<string_view> StrSplit(string_view const& text,
                                       char const delim);
 

--- a/src/s2/third_party/absl/strings/str_split.h
+++ b/src/s2/third_party/absl/strings/str_split.h
@@ -20,7 +20,7 @@ std::vector<String> StrSplit(String const& text, char delim);
 // Returns false if the given StringPiece is empty, indicating that the
 // StrSplit() API should omit the empty string.
 //
-// std::vector<string> v = StrSplit(" a , ,,b,", ',', SkipEmpty());
+// std::vector<std::string> v = StrSplit(" a , ,,b,", ',', SkipEmpty());
 // EXPECT_THAT(v, ElementsAre(" a ", " ", "b"));
 struct SkipEmpty {
   bool operator()(string_view sv) const { return !sv.empty(); }
@@ -29,7 +29,7 @@ struct SkipEmpty {
 // Returns false if the given string is empty or contains only whitespace,
 // indicating that the StrSplit() API should omit the string.
 //
-// std::vector<string> v = StrSplit(" a , ,,b,", ',', SkipWhitespace());
+// std::vector<std::string> v = StrSplit(" a , ,,b,", ',', SkipWhitespace());
 // EXPECT_THAT(v, ElementsAre(" a ", "b"));
 struct SkipWhitespace {
   bool operator()(string_view sv) const {

--- a/src/s2/third_party/absl/strings/string_view.h
+++ b/src/s2/third_party/absl/strings/string_view.h
@@ -23,7 +23,7 @@
 // another `string_view`.
 //
 // This `absl::string_view` abstraction is designed to be a drop-in
-// replacement for the C++17 `std::string_view` abstraction.
+// replacement for the C++17 `string_view` abstraction.
 #ifndef S2_THIRD_PARTY_ABSL_STRINGS_STRING_VIEW_H_
 #define S2_THIRD_PARTY_ABSL_STRINGS_STRING_VIEW_H_
 
@@ -35,7 +35,7 @@
 #include <string_view>
 
 namespace absl {
-using std::string_view;
+using string_view;
 }  // namespace absl
 
 #else  // ABSL_HAVE_STD_STRING_VIEW
@@ -62,7 +62,7 @@ using std::string_view;
 //   is 32 bits in LP32, 64 bits in LP64, 64 bits in LLP64
 //   future changes intended
 //
-typedef string::difference_type stringpiece_ssize_type;
+typedef std::string::difference_type stringpiece_ssize_type;
 
 namespace absl {
 
@@ -579,7 +579,7 @@ namespace absl {
 // ClippedSubstr()
 //
 // Like `s.substr(pos, n)`, but clips `pos` to an upper bound of `s.size()`.
-// Provided because std::string_view::substr throws if `pos > size()`
+// Provided because string_view::substr throws if `pos > size()`
 inline string_view ClippedSubstr(string_view s, size_t pos,
                                  size_t n = string_view::npos) {
   pos = (std::min)(pos, static_cast<size_t>(s.size()));
@@ -592,7 +592,7 @@ inline string_view ClippedSubstr(string_view s, size_t pos,
 // This function should be used where an `absl::string_view` can be created from
 // a possibly-null pointer.
 // Our absl::string_view has historically been constructible from a null-valued
-// pointer, but the same null value isn't valid for std::string_view.
+// pointer, but the same null value isn't valid for string_view.
 inline string_view NullSafeStringView(const char* p) {
   return p ? string_view(p) : string_view();
 }

--- a/src/s2/third_party/absl/strings/strip.cc
+++ b/src/s2/third_party/absl/strings/strip.cc
@@ -33,7 +33,7 @@ void ReplaceCharacters(char* str, size_t len, absl::string_view remove,
   }
 }
 
-void ReplaceCharacters(string* s, absl::string_view remove, char replace_with) {
+void ReplaceCharacters(std::string* s, absl::string_view remove, char replace_with) {
   for (char& ch : *s) {
     if (remove.find(ch) != absl::string_view::npos) {
       ch = replace_with;

--- a/src/s2/third_party/absl/strings/strip.h
+++ b/src/s2/third_party/absl/strings/strip.h
@@ -96,7 +96,7 @@ ABSL_MUST_USE_RESULT inline absl::string_view StripSuffix(
 // Use icu::UnicodeSet and its spanUTF8()/spanBackUTF8().
 void ReplaceCharacters(char* str, size_t len, absl::string_view remove,
                        char replace_with);
-void ReplaceCharacters(string* s, absl::string_view remove, char replace_with);
+void ReplaceCharacters(std::string* s, absl::string_view remove, char replace_with);
 
 // Replaces the character 'remove' with the character 'replace_with'.
 //
@@ -108,7 +108,7 @@ inline void ReplaceCharacter(char* str, size_t len, char remove,
 }
 
 ABSL_DEPRECATED("Use absl::StripAsciiWhitespace() instead")
-inline void StripWhitespace(string* str) { absl::StripAsciiWhitespace(str); }
+inline void StripWhitespace(std::string* str) { absl::StripAsciiWhitespace(str); }
 
 ABSL_DEPRECATED("Use absl::StripAsciiWhitespace() instead")
 inline void StripWhitespace(absl::string_view* str) {

--- a/src/s2/third_party/absl/types/span.h
+++ b/src/s2/third_party/absl/types/span.h
@@ -93,7 +93,7 @@ constexpr auto GetDataImpl(C& c, int) noexcept  // NOLINT(runtime/references)
 }
 
 // Before C++17, string::data returns a const char* in all cases.
-inline char* GetDataImpl(string& s,  // NOLINT(runtime/references)
+inline char* GetDataImpl(std::string& s,  // NOLINT(runtime/references)
                          int) noexcept {
   return &s[0];
 }

--- a/src/s2/util/coding/varint.cc
+++ b/src/s2/util/coding/varint.cc
@@ -276,13 +276,13 @@ const char* Varint::Skip64BackwardSlow(const char* p, const char* b) {
   return nullptr; // value is too long to be a varint64
 }
 
-void Varint::Append32Slow(string* s, uint32 value) {
+void Varint::Append32Slow(std::string* s, uint32 value) {
   const size_t start = s->size();
   s->resize(start + Varint::Length32(value));
   Varint::Encode32(&((*s)[start]), value);
 }
 
-void Varint::Append64Slow(string* s, uint64 value) {
+void Varint::Append64Slow(std::string* s, uint64 value) {
   const size_t start = s->size();
   s->resize(start + Varint::Length64(value));
   Varint::Encode64(&((*s)[start]), value);

--- a/src/s2/util/coding/varint.h
+++ b/src/s2/util/coding/varint.h
@@ -119,8 +119,8 @@ class Varint {
   static int Length64(uint64 v);
 
   // EFFECTS    Appends the varint representation of "value" to "*s".
-  static void Append32(string* s, uint32 value);
-  static void Append64(string* s, uint64 value);
+  static void Append32(std::string* s, uint32 value);
+  static void Append64(std::string* s, uint64 value);
 
   // EFFECTS    Encodes a pair of values to "*s".  The encoding
   //            is done by weaving together 4 bit groups of
@@ -129,7 +129,7 @@ class Varint {
   //            that if both a and b are small, both values can be
   //            encoded in a single byte.
   ABSL_DEPRECATED("Use TwoValuesVarint::Encode32.")
-  static void EncodeTwo32Values(string* s, uint32 a, uint32 b);
+  static void EncodeTwo32Values(std::string* s, uint32 a, uint32 b);
   ABSL_DEPRECATED("Use TwoValuesVarint::Decode32.")
   static const char* DecodeTwo32Values(const char* ptr, uint32* a, uint32* b);
   ABSL_DEPRECATED("Use TwoValuesVarint::Decode32WithLimit.")
@@ -167,8 +167,8 @@ class Varint {
   static const char* Skip32BackwardSlow(const char* ptr, const char* base);
   static const char* Skip64BackwardSlow(const char* ptr, const char* base);
 
-  static void Append32Slow(string* s, uint32 value);
-  static void Append64Slow(string* s, uint64 value);
+  static void Append32Slow(std::string* s, uint32 value);
+  static void Append64Slow(std::string* s, uint64 value);
 
 };
 
@@ -397,7 +397,7 @@ inline int Varint::Length64(uint64 v) {
   return static_cast<int>((log2value * 9 + 73) / 64);
 }
 
-inline void Varint::Append32(string* s, uint32 value) {
+inline void Varint::Append32(std::string* s, uint32 value) {
   // Inline the fast-path for single-character output, but fall back to the .cc
   // file for the full version. The size<capacity check is so the compiler can
   // optimize out the string resize code.
@@ -408,7 +408,7 @@ inline void Varint::Append32(string* s, uint32 value) {
   }
 }
 
-inline void Varint::Append64(string* s, uint64 value) {
+inline void Varint::Append64(std::string* s, uint64 value) {
   // Inline the fast-path for single-character output, but fall back to the .cc
   // file for the full version. The size<capacity check is so the compiler can
   // optimize out the string resize code.

--- a/src/s2/util/gtl/btree.h
+++ b/src/s2/util/gtl/btree.h
@@ -119,7 +119,7 @@ namespace internal_btree {
 //    bool operator()(const string &a, const char* b) const {
 //      return strcmp(a.c_str(), b) < 0;
 //    }
-//    bool operator()(const char* a, const string& b) const {
+//    bool operator()(const char* a, const std::string& b) const {
 //      return strcmp(a, b.c_str()) < 0;
 //    }
 //    using is_transparent = void;

--- a/src/s2/util/gtl/container_logging.h
+++ b/src/s2/util/gtl/container_logging.h
@@ -200,8 +200,8 @@ class RangeLogger {
 
   // operator<< above is generally recommended. However, some situations may
   // require a string, so a convenience str() method is provided as well.
-  string str() const {
-    string s;
+  std::string str() const {
+    std::string s;
     ::strings::OStringStream(&s) << *this;
     return s;
   }

--- a/src/s2/util/math/exactfloat/exactfloat.cc
+++ b/src/s2/util/math/exactfloat/exactfloat.cc
@@ -360,22 +360,22 @@ int ExactFloat::NumSignificantDigitsForPrec(int prec) {
 // (e.g. 1/512 == 0.001953125 formatted as 0.002).
 static const int kMinSignificantDigits = 10;
 
-string ExactFloat::ToString() const {
+std::string ExactFloat::ToString() const {
   int max_digits = max(kMinSignificantDigits,
                        NumSignificantDigitsForPrec(prec()));
   return ToStringWithMaxDigits(max_digits);
 }
 
-string ExactFloat::ToStringWithMaxDigits(int max_digits) const {
+std::string ExactFloat::ToStringWithMaxDigits(int max_digits) const {
   S2_DCHECK_GT(max_digits, 0);
   if (!is_normal()) {
     if (is_nan()) return "nan";
     if (is_zero()) return (sign_ < 0) ? "-0" : "0";
     return (sign_ < 0) ? "-inf" : "inf";
   }
-  string digits;
+  std::string digits;
   int exp10 = GetDecimalDigits(max_digits, &digits);
-  string str;
+  std::string str;
   if (sign_ < 0) str.push_back('-');
 
   // We use the standard '%g' formatting rules.  If the exponent is less than
@@ -421,8 +421,8 @@ string ExactFloat::ToStringWithMaxDigits(int max_digits) const {
 }
 
 // Increment an unsigned integer represented as a string of ASCII digits.
-static void IncrementDecimalDigits(string* digits) {
-  string::iterator pos = digits->end();
+static void IncrementDecimalDigits(std::string* digits) {
+  std::string::iterator pos = digits->end();
   while (--pos >= digits->begin()) {
     if (*pos < '9') { ++*pos; return; }
     *pos = '0';
@@ -430,7 +430,7 @@ static void IncrementDecimalDigits(string* digits) {
   digits->insert(0, "1");
 }
 
-int ExactFloat::GetDecimalDigits(int max_digits, string* digits) const {
+int ExactFloat::GetDecimalDigits(int max_digits, std::string* digits) const {
   S2_DCHECK(is_normal());
   // Convert the value to the form (bn * (10 ** bn_exp10)) where "bn" is a
   // positive integer (BIGNUM).
@@ -481,7 +481,7 @@ int ExactFloat::GetDecimalDigits(int max_digits, string* digits) const {
 
   // Now strip any trailing zeros.
   S2_DCHECK_NE((*digits)[0], '0');
-  string::iterator pos = digits->end();
+  std::string::iterator pos = digits->end();
   while (pos[-1] == '0') --pos;
   if (pos < digits->end()) {
     bn_exp10 += digits->end() - pos;
@@ -494,7 +494,7 @@ int ExactFloat::GetDecimalDigits(int max_digits, string* digits) const {
   return bn_exp10 + digits->size();
 }
 
-string ExactFloat::ToUniqueString() const {
+std::string ExactFloat::ToUniqueString() const {
   char prec_buf[20];
   sprintf(prec_buf, "<%d>", prec());
   return ToString() + prec_buf;

--- a/src/s2/util/math/exactfloat/exactfloat.h
+++ b/src/s2/util/math/exactfloat/exactfloat.h
@@ -299,17 +299,17 @@ class ExactFloat {
   // Note that if two values have different precisions, they may have the same
   // ToString() value even though their values are slightly different.  If you
   // need to distinguish such values, use ToUniqueString() intead.
-  string ToString() const;
+  std::string ToString() const;
 
   // Return a string formatted according to printf("%Ng") where N is the given
   // maximum number of significant digits.
-  string ToStringWithMaxDigits(int max_digits) const;
+  std::string ToStringWithMaxDigits(int max_digits) const;
 
   // Return a human-readable string such that if two ExactFloats have different
   // values, then their string representations are always different.  This
   // method is useful for debugging.  The string has the form "value<prec>",
   // where "prec" is the actual precision of the ExactFloat (e.g., "0.215<50>").
-  string ToUniqueString() const;
+  std::string ToUniqueString() const;
 
   // Return an upper bound on the number of significant digits required to
   // distinguish any two floating-point numbers with the given precision when
@@ -563,7 +563,7 @@ class ExactFloat {
   // Convert the ExactFloat to a decimal value of the form 0.ddd * (10 ** x),
   // with at most "max_digits" significant digits (trailing zeros are removed).
   // Set (*digits) to the ASCII digits and return the decimal exponent "x".
-  int GetDecimalDigits(int max_digits, string* digits) const;
+  int GetDecimalDigits(int max_digits, std::string* digits) const;
 
   // Return a_sign * fabs(a) + b_sign * fabs(b).  Used to implement addition
   // and subtraction.


### PR DESCRIPTION
Exposing the "using" directive in the port header will cause it
to be leaked into any codebase that uses this library. While it
is possible to just fix up the headers and use the directive
only in the source files, this change uses std::string
everywhere.